### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,9 @@
 # CODEOWNERS — auto-assigned reviewers on PRs.
 # Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Syntax rule: one pattern per line. Multiple patterns separated by
+# whitespace on a single line are NOT supported — GitHub treats the
+# first token as the pattern and everything after it as owners.
 
 # Default: every file, unless a more specific rule matches below.
 *                                   @workforce0
@@ -7,7 +11,10 @@
 # Infra & deploy
 /.github/                           @workforce0
 /docker-compose.prod.yml            @workforce0
-/fly.toml /railway.json /render.yaml /.do/    @workforce0
+/fly.toml                           @workforce0
+/railway.json                       @workforce0
+/render.yaml                        @workforce0
+/.do/                               @workforce0
 
 # Backend (Fastify + Prisma + services)
 /backend/prisma/                    @workforce0
@@ -23,9 +30,10 @@
 # Agent daemon
 /agent/                             @workforce0
 
-# Docs site — relax review gate so typo fixes can flow
+# Docs site
 /docs-site/src/content/docs/        @workforce0
 
-# Strategy documents — extra eyes
-/CLAUDE.md /AGENTS.md               @workforce0
+# Strategy documents
+/CLAUDE.md                          @workforce0
+/AGENTS.md                          @workforce0
 /docs/PRD-Workforce0-Platform.md    @workforce0

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,57 +1,31 @@
-# CODEOWNERS for Workforce0
-#
-# This file defines who is automatically requested for review when a pull
-# request modifies matching paths. Rules are evaluated top-to-bottom; the
-# LAST matching pattern takes precedence. Patterns follow a subset of
-# gitignore syntax.
-#
-# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-#
-# Current status: solo-maintained OSS project. As the community grows,
-# domain-specific owners will be added below. See the note at the bottom
-# for how to become a code owner for a given area.
+# CODEOWNERS — auto-assigned reviewers on PRs.
+# Docs: https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# -----------------------------------------------------------------------------
-# Default owner — applies to every file unless a later rule overrides it.
-# -----------------------------------------------------------------------------
-*                                   @ithadmin
+# Default: every file, unless a more specific rule matches below.
+*                                   @workforce0
 
-# -----------------------------------------------------------------------------
-# Security-sensitive paths
-# TODO: add a second maintainer here once the project has more contributors,
-# so security-critical changes always get a second set of eyes.
-# -----------------------------------------------------------------------------
-SECURITY.md                         @ithadmin
-/.github/                           @ithadmin
-/.github/workflows/                 @ithadmin
+# Infra & deploy
+/.github/                           @workforce0
+/docker-compose.prod.yml            @workforce0
+/fly.toml /railway.json /render.yaml /.do/    @workforce0
 
-# Auth, encryption, and request middleware — handle with extra care.
-/mvp/src/services/auth/             @ithadmin
-/mvp/src/lib/encryption*            @ithadmin
-/mvp/src/middleware/                @ithadmin
+# Backend (Fastify + Prisma + services)
+/backend/prisma/                    @workforce0
+/backend/src/services/chief-of-staff/   @workforce0
+/backend/src/services/model-registry/   @workforce0
+/backend/src/services/project-graph/    @workforce0
+/backend/src/lib/                   @workforce0
+/backend/src/middleware/            @workforce0
 
-# Database migrations are irreversible in production; review carefully.
-/mvp/prisma/migrations/             @ithadmin
+# Frontend
+/frontend/src/                      @workforce0
 
-# -----------------------------------------------------------------------------
-# Frontend stack
-# Reserved for a future frontend lead; currently owned by @ithadmin.
-# -----------------------------------------------------------------------------
-/frontend/                          @ithadmin
+# Agent daemon
+/agent/                             @workforce0
 
-# -----------------------------------------------------------------------------
-# Agent daemon (user-side lightweight agent)
-# -----------------------------------------------------------------------------
-/agent/                             @ithadmin
+# Docs site — relax review gate so typo fixes can flow
+/docs-site/src/content/docs/        @workforce0
 
-# -----------------------------------------------------------------------------
-# Third-party integrations (Jira, Google Chat, Drive, Twilio, WorkOS, ...)
-# -----------------------------------------------------------------------------
-/mvp/src/services/integrations/     @ithadmin
-
-# -----------------------------------------------------------------------------
-# How to become a code owner
-#
-# To become a code owner for an area, open an issue proposing it and
-# contribute 3+ merged PRs in that area.
-# -----------------------------------------------------------------------------
+# Strategy documents — extra eyes
+/CLAUDE.md /AGENTS.md               @workforce0
+/docs/PRD-Workforce0-Platform.md    @workforce0


### PR DESCRIPTION
Adds a `.github/CODEOWNERS` routing PR review assignment.

**Default:** `*` → @workforce0.

**Per-path rules** for .github/, backend/prisma, service hot paths (chief-of-staff, model-registry, project-graph), middleware, frontend, agent, docs-site content, and strategy documents (CLAUDE.md / AGENTS.md / PRD).

Effect: when anyone opens a PR touching one of these paths, GitHub automatically requests a review from the owner. Improves triage for future contributors.

(This PR also serves as a smoke test for the AI-review bots just installed: CodeRabbit, Greptile, Cubic.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership rules: default owner changed to a new team and legacy ownership mappings removed.
  * Introduced narrower ownership assignments for infra/deploy, backend, frontend, agent, and documentation areas to improve review routing and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->