### PR TITLE
fix(voice-intake): correct 6 contracts found running locally end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ docs-site/.DS_Store
 graphify-out/
 tsconfig.tsbuildinfo
 **/tsconfig.tsbuildinfo
+
+# Local dev override (host Ollama reuse, dev-only secrets)
+docker-compose.override.yml

--- a/bin/diagnose-voice.sh
+++ b/bin/diagnose-voice.sh
@@ -6,15 +6,26 @@
 #   - The pipecat-bridge container started with DEBUG=1 (gates the synthetic endpoint)
 #   - $BRIDGE_JWT_SECRET exported (matches the value in .env)
 #   - tests/fixtures/voice-intake-sample.wav (commit-tracked or generated locally)
+#
+# Optional:
+#   - $COMPOSE_PROJECT_NAME (default: parent dir name) — must match the project
+#     used at `docker compose ... up`. Without this the ps lookups silently
+#     report "not running" even when services are up under a non-default project.
+#   - $BRIDGE_HOST_PORT (default: 8400) — host port the bridge is published on.
 
 set -uo pipefail
 cd "$(dirname "$0")/.."
 
+PROJECT="${COMPOSE_PROJECT_NAME:-$(basename "$(pwd)")}"
+BRIDGE_HOST_PORT="${BRIDGE_HOST_PORT:-8400}"
+
 echo "Workforce0 voice diagnostic — $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo "  project = $PROJECT"
+echo "  bridge  = http://localhost:${BRIDGE_HOST_PORT}"
 echo "─────────────────────────────────────"
 
 for svc in whisper ollama kokoro-tts pipecat-bridge; do
-  cid=$(docker compose -f docker-compose.prod.yml ps -q "$svc" 2>/dev/null || true)
+  cid=$(docker compose -f docker-compose.prod.yml -p "$PROJECT" ps -q "$svc" 2>/dev/null || true)
   if [ -z "$cid" ]; then echo "[$svc] not running"; continue; fi
   health=$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}n/a{{end}}' "$cid" 2>/dev/null || echo unknown)
   echo "[$svc] health=$health"
@@ -25,11 +36,9 @@ echo
 # The bridge exposes /sessions/synthetic only when DEBUG=1 (see voice.md).
 SAMPLE="tests/fixtures/voice-intake-sample.wav"
 if [ ! -f "$SAMPLE" ]; then
-  # Operator can generate this on first run if it isn't committed:
-  #   say -o tests/fixtures/voice-intake-sample.wav --data-format=LEI16@16000 "hello this is a test"
-  # (or use espeak-ng / any other TTS that writes < 100 KB 16-kHz mono PCM WAV.)
   echo "Sample WAV missing: $SAMPLE"
   echo "Generate one with: say -o $SAMPLE --data-format=LEI16@16000 \"hello this is a test\""
+  echo "  (or use espeak-ng / any TTS that writes a small 16-kHz mono PCM WAV)"
   exit 2
 fi
 
@@ -39,11 +48,32 @@ if [ -z "${BRIDGE_JWT_SECRET:-}" ]; then
 fi
 
 echo "Posting sample WAV to bridge synthetic endpoint…"
-TOKEN=$(node -e "
-  const jwt = require('jsonwebtoken');
-  console.log(jwt.sign({ callId: 'diag', tenantId: 'default', sessionId: 'diag' },
-    process.env.BRIDGE_JWT_SECRET, { expiresIn: '5m' }));
-")
-curl -fsS -X POST "http://localhost:8400/sessions/synthetic?token=$TOKEN" \
-  -H "Content-Type: audio/wav" --data-binary "@$SAMPLE" | head -c 500
+
+# Mint JWT in Python so we don't need a Node install or `npm i jsonwebtoken`.
+# Python 3 stdlib ships everything we need (json, base64, hmac, hashlib).
+TOKEN=$(BRIDGE_JWT_SECRET="$BRIDGE_JWT_SECRET" python3 - <<'PY'
+import base64, hashlib, hmac, json, os, time
+
+secret = os.environ["BRIDGE_JWT_SECRET"].encode()
+
+def b64(data: bytes) -> bytes:
+    return base64.urlsafe_b64encode(data).rstrip(b"=")
+
+header  = b64(json.dumps({"alg": "HS256", "typ": "JWT"}, separators=(",", ":")).encode())
+payload = b64(json.dumps(
+    {"callId": "diag", "tenantId": "default", "sessionId": "diag", "exp": int(time.time()) + 300},
+    separators=(",", ":"),
+).encode())
+sig = b64(hmac.new(secret, header + b"." + payload, hashlib.sha256).digest())
+print((header + b"." + payload + b"." + sig).decode())
+PY
+)
+
+if [ -z "$TOKEN" ]; then
+  echo "Failed to mint JWT (python3 missing or hmac failure)"
+  exit 3
+fi
+
+curl -fsS -X POST "http://localhost:${BRIDGE_HOST_PORT}/sessions/synthetic?token=${TOKEN}" \
+  -H "Content-Type: audio/wav" --data-binary "@$SAMPLE" | head -c 1024
 echo

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -161,24 +161,31 @@ services:
   # ---------------------------------------------------------------------------
   # Kokoro TTS (local-voice profile, opt-in via COMPOSE_PROFILES=local-voice)
   # ---------------------------------------------------------------------------
-  # TODO(image-verify): The `ghcr.io/remsky/kokoro-fastapi:latest` tag is the
-  # canonical published image per the Kokoro-FastAPI README, but anonymous
-  # GHCR manifest fetch returns 401 so the tag could not be confirmed at
-  # compose-write time. If pull fails at deploy, fall back to a Docker Hub
-  # search ("remsky/kokoro-fastapi") or build locally from the upstream repo
-  # (https://github.com/remsky/Kokoro-FastAPI) and replace this `image:` line
-  # with a `build:` block.
+  # Built from a thin wrapper around upstream remsky/Kokoro-FastAPI. The
+  # canonical ghcr.io/remsky/kokoro-fastapi tag is anonymous-fetch
+  # unauthorized (401) so we clone-and-build at image-build time. The pin
+  # in infra/kokoro/Dockerfile fixes a known-good upstream commit; bump it
+  # there when we deliberately upgrade. The build downloads the Kokoro v1_0
+  # weights into the image, so first build is ~10–15 min on CPU.
+  #
+  # Healthcheck note: the upstream image has curl but not wget — the
+  # previous wget-based check left this service permanently in `starting`
+  # status, blocking pipecat-bridge's depends_on.
   kokoro-tts:
-    image: ghcr.io/remsky/kokoro-fastapi:latest
+    build:
+      context: ./infra/kokoro
+      dockerfile: Dockerfile
     container_name: workforce0-kokoro-tts
     restart: unless-stopped
     profiles: ["local-voice"]
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8880/health || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8880/health || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 60s
+      # Cold-start has to load the model into memory; first call after boot
+      # also re-warms voice packs, hence the long start_period.
+      start_period: 5m
     networks:
       - workforce0
 
@@ -226,15 +233,28 @@ services:
     # rationale — single-profile deploys still get a working voice stack
     # without having to know about transitive dependencies.
     profiles: ["local-stt", "local-voice"]
+    # Default model: `Systran/faster-whisper-small`. Operators who want
+    # higher accuracy at the cost of latency/RAM can set
+    # WHISPER_MODEL=Systran/faster-whisper-large-v3 (or any non-gated CT2
+    # repo). `Systran/faster-whisper-large-v3-turbo` is currently HF-gated
+    # and returns 401 on anonymous pull — do not use it as a default.
     environment:
-      WHISPER__MODEL: ${WHISPER_MODEL:-Systran/faster-whisper-large-v3-turbo}
+      WHISPER__MODEL: ${WHISPER_MODEL:-Systran/faster-whisper-small}
       WHISPER__INFERENCE_DEVICE: ${WHISPER_INFERENCE_DEVICE:-auto}
       WHISPER__COMPUTE_TYPE: ${WHISPER_COMPUTE_TYPE:-int8}
-      PRELOAD_MODELS: '["${WHISPER_MODEL:-Systran/faster-whisper-large-v3-turbo}"]'
+      PRELOAD_MODELS: '["${WHISPER_MODEL:-Systran/faster-whisper-small}"]'
     volumes:
       - whisper_cache:/root/.cache/huggingface
+    # Healthcheck uses python3 (always present in the slim base) instead of
+    # wget which is not installed; without this the container never reports
+    # healthy and the bridge's depends_on blocks the whole stack.
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8000/health || exit 1"]
+      test:
+        - CMD-SHELL
+        - >
+          python3 -c "import urllib.request,sys;
+          sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/health',timeout=3).status==200 else 1)"
+          || exit 1
       interval: 30s
       timeout: 5s
       retries: 3

--- a/infra/kokoro/Dockerfile
+++ b/infra/kokoro/Dockerfile
@@ -1,0 +1,82 @@
+# Kokoro-FastAPI build wrapper.
+#
+# Why this exists: ghcr.io/remsky/kokoro-fastapi:* is anonymous-fetch
+# unauthorized (401), so a vanilla `image:` reference cannot be pulled by an
+# operator who hasn't logged into GHCR with credentials they don't have.
+# We clone the upstream public repo at a pinned commit and run their CPU
+# Dockerfile build, producing a local image tag the compose stack uses.
+#
+# Bump KOKORO_REF when we deliberately upgrade. After a bump, run:
+#   docker compose -p wf0 --profile local-voice build kokoro-tts
+# and re-verify with `bin/diagnose-voice.sh`.
+#
+# First build is ~10–15 min on CPU and produces a ~5 GB image (PyTorch CPU
+# wheel + Kokoro v1_0 weights baked in).
+
+ARG KOKORO_REPO=https://github.com/remsky/Kokoro-FastAPI.git
+ARG KOKORO_REF=3af45719940c915b53ad2a63f9cdb6f22680d276
+
+FROM alpine/git:latest AS source
+ARG KOKORO_REPO
+ARG KOKORO_REF
+WORKDIR /src
+RUN git clone "$KOKORO_REPO" . \
+ && git checkout "$KOKORO_REF" \
+ && rm -rf .git
+
+# Use the upstream CPU Dockerfile verbatim against the cloned tree.
+# Trick: re-export the source stage as the build context for a nested build
+# is awkward in pure Dockerfile, so instead we replicate upstream's CPU
+# stages here and COPY --from=source. This keeps the build reproducible
+# without depending on a `docker build` from a different cwd.
+
+FROM python:3.10-slim AS runtime
+
+# Match upstream apt list (CPU Dockerfile).
+RUN apt-get update -y \
+ && apt-get install -y --no-install-recommends \
+        espeak-ng espeak-ng-data git libsndfile1 curl ffmpeg g++ cmake ca-certificates \
+ && apt-get clean && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /usr/share/espeak-ng-data \
+ && ln -s /usr/lib/*/espeak-ng-data/* /usr/share/espeak-ng-data/ \
+ && curl -LsSf https://astral.sh/uv/install.sh | sh \
+ && mv /root/.local/bin/uv /usr/local/bin/ \
+ && mv /root/.local/bin/uvx /usr/local/bin/ \
+ && useradd -m -u 1000 appuser \
+ && mkdir -p /app/api/src/models/v1_0 \
+ && chown -R appuser:appuser /app
+
+USER appuser
+WORKDIR /app
+
+# Rust is required to build sudachipy / pyopenjtalk-plus on first sync.
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="/home/appuser/.cargo/bin:/app/.venv/bin:$PATH" \
+    UV_HTTP_TIMEOUT=120 \
+    UV_HTTP_RETRIES=3
+
+COPY --from=source --chown=appuser:appuser /src/pyproject.toml ./pyproject.toml
+RUN uv venv --python 3.10 \
+ && uv sync --extra cpu --no-cache
+
+COPY --from=source --chown=appuser:appuser /src/api ./api
+COPY --from=source --chown=appuser:appuser /src/web ./web
+COPY --from=source --chown=appuser:appuser /src/docker/scripts/ ./
+RUN chmod +x ./entrypoint.sh
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app:/app/api \
+    UV_LINK_MODE=copy \
+    USE_GPU=false \
+    PHONEMIZER_ESPEAK_PATH=/usr/bin \
+    PHONEMIZER_ESPEAK_DATA=/usr/share/espeak-ng-data \
+    ESPEAK_DATA_PATH=/usr/share/espeak-ng-data \
+    DEVICE="cpu" \
+    DOWNLOAD_MODEL=true
+
+# Bake the model weights into the image so first-call latency isn't
+# dominated by a fresh download. Uses upstream download_model helper.
+RUN python download_model.py --output api/src/models/v1_0
+
+EXPOSE 8880
+CMD ["./entrypoint.sh"]

--- a/infra/pipecat-bridge/tests/test_adapters.py
+++ b/infra/pipecat-bridge/tests/test_adapters.py
@@ -69,11 +69,51 @@ async def test_llm_chat_completion():
 
 
 @pytest.mark.asyncio
-async def test_tts_returns_pcm_bytes():
-    _install_mock_client(TTSAdapter, content=b"\x00" * 100)
-    adapter = TTSAdapter("http://kokoro-tts:8880")
-    audio = await adapter.synthesize("hello")
-    assert audio == b"\x00" * 100
+async def test_tts_calls_kokoro_speech_endpoint_with_pcm_request():
+    """Pin the request shape to upstream Kokoro-FastAPI's OpenAI-compat schema.
+
+    A previous version called /v1/audio/synthesize with {text, voice, format} —
+    a fictional endpoint that 404s on the real image. This test asserts we
+    call /v1/audio/speech with {model, input, voice, response_format, stream}
+    so a future regression of that mistake is caught at unit-test time.
+    """
+    # 24 kHz s16le silence — 1 second worth, large enough that ratecv has
+    # something to resample without hitting its small-input degenerate path.
+    pcm_24k_silence = b"\x00\x00" * 24000
+    mock = _install_mock_client(TTSAdapter, content=pcm_24k_silence)
+    adapter = TTSAdapter("http://kokoro-tts:8880", voice="af_heart")
+    audio = await adapter.synthesize("hello world")
+
+    url = mock.post.call_args.args[0]
+    body = mock.post.call_args.kwargs["json"]
+    assert url.endswith("/v1/audio/speech")
+    assert body == {
+        "model": "kokoro",
+        "input": "hello world",
+        "voice": "af_heart",
+        "response_format": "pcm",
+        "stream": False,
+    }
+    # 24 kHz s16le → 8 kHz μ-law: 6× compression. Allow a few-byte slop
+    # from ratecv state but assert the right order of magnitude.
+    assert len(audio) == pytest.approx(len(pcm_24k_silence) // 6, abs=4)
+
+
+def test_pcm24k_to_twilio_mulaw_byte_ratio_and_silence_value():
+    """Direct unit test for the resample/companding helper."""
+    from tts_adapter import pcm24k_to_twilio_mulaw
+
+    # 1 s of s16le silence at 24 kHz = 48000 bytes → ~8000 μ-law bytes.
+    pcm_silence = b"\x00\x00" * 24000
+    out = pcm24k_to_twilio_mulaw(pcm_silence)
+    assert len(out) == pytest.approx(8000, abs=4)
+    # μ-law silence is 0xFF (the encoded value for amplitude 0).
+    # Allow a small startup transient from ratecv but everything settles to
+    # 0xFF for a silent input.
+    silent_count = sum(1 for b in out if b == 0xFF)
+    assert silent_count >= len(out) - 4, (
+        f"expected nearly all μ-law silence (0xFF), got {silent_count}/{len(out)}"
+    )
 
 
 @pytest.mark.asyncio

--- a/infra/pipecat-bridge/tests/test_tts_live.py
+++ b/infra/pipecat-bridge/tests/test_tts_live.py
@@ -1,0 +1,54 @@
+"""Live contract test against a real Kokoro-FastAPI instance.
+
+Skipped unless KOKORO_BASE_URL is set in the environment. When the local-voice
+compose profile is up, run with:
+
+    KOKORO_BASE_URL=http://localhost:8880 pytest tests/test_tts_live.py -v
+
+This exists because the mocked test in test_adapters.py only validates the
+request *shape* — it cannot catch an endpoint or schema drift on the upstream
+Kokoro side. PR #41 originally called a fictional /v1/audio/synthesize because
+no live test pinned the contract.
+"""
+from __future__ import annotations
+
+import os
+import pytest
+
+from tts_adapter import TTSAdapter
+
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("KOKORO_BASE_URL"),
+    reason="KOKORO_BASE_URL not set; skipping live Kokoro test",
+)
+
+
+@pytest.mark.asyncio
+async def test_synthesize_returns_twilio_ready_mulaw():
+    base_url = os.environ["KOKORO_BASE_URL"]
+    TTSAdapter._shared_client = None  # ensure fresh client for live run
+    adapter = TTSAdapter(base_url, voice="af_heart")
+    try:
+        audio = await adapter.synthesize("This is a workforce zero diagnostic.")
+    finally:
+        await TTSAdapter.aclose_shared()
+
+    # μ-law @ 8 kHz mono = 8 KB/s. A short sentence must be at least ~2 s
+    # of speech; below 8 KB something silently truncated upstream.
+    assert isinstance(audio, bytes)
+    assert len(audio) >= 8000, f"suspiciously short μ-law payload: {len(audio)} bytes"
+    # Common header magic bytes that would indicate response_format silently
+    # flipped to wav/mp3 — fail loudly so the regression is caught.
+    assert audio[:4] != b"RIFF", "got WAV header — response_format=pcm not honored"
+    assert audio[:3] != b"ID3", "got MP3 — response_format=pcm not honored"
+    # μ-law is byte-encoded, so any signed-16-bit PCM tell would mean we
+    # forgot the lin2ulaw step. Detection isn't perfect (random PCM bytes
+    # can look like μ-law) but a stuck "all 0x00" PCM-silence pattern
+    # would never appear from a μ-law-encoded utterance — μ-law silence is
+    # 0xFF, so a long run of 0x00 == raw PCM leaked through.
+    null_run = max(
+        (sum(1 for _ in g) for v, g in __import__("itertools").groupby(audio) if v == 0),
+        default=0,
+    )
+    assert null_run < 16, "long 0x00 run — looks like raw PCM, not μ-law"

--- a/infra/pipecat-bridge/tts_adapter.py
+++ b/infra/pipecat-bridge/tts_adapter.py
@@ -1,19 +1,62 @@
-"""Calls Kokoro TTS container's HTTP synthesize endpoint, returns raw PCM bytes.
+"""Calls Kokoro-FastAPI's OpenAI-compatible /v1/audio/speech, returns Twilio-
+ready μ-law bytes (8 kHz mono).
 
-Shares a class-level `httpx.AsyncClient` to keep keepalive across calls.
+Why we transcode here, not in the TS provider
+─────────────────────────────────────────────
+Kokoro hands back raw PCM at 24 kHz s16le mono. Twilio Media Streams expects
+μ-law 8 kHz mono base64-encoded inside `media.payload`. The TS-side bridge
+provider (`backend/.../pipecat.provider.ts`) already assumes "the bridge
+produces mu-law bytes" and just base64-encodes them — see the comment near
+the `event:'media'` send. Doing the resample + companding here keeps that
+contract honest. A previous version of this adapter returned raw PCM and
+silently broke any real Twilio call.
+
+Pipeline:
+  POST /v1/audio/speech response_format=pcm  →  16-bit LE mono @ 24 kHz
+  audioop.ratecv()                          →  16-bit LE mono @ 8 kHz
+  audioop.lin2ulaw()                        →  μ-law mono @ 8 kHz (1 byte/sample)
+
+Byte budget: 1 second of speech is 48,000 bytes from Kokoro and ends as 8,000
+bytes on the wire — a 6× reduction. If the live test sees a smaller ratio
+something is mis-encoded.
+
+Note on Python 3.13: `audioop` is removed in 3.13. The bridge pyproject pins
+`>=3.12,<3.13`, so this is safe today; if we widen that, swap to a numpy or
+pyaudioop_compat fallback.
+
+Shares a class-level httpx.AsyncClient to keep keepalive across calls.
 See stt_adapter.py for lifecycle notes.
 """
 
 from __future__ import annotations
 import asyncio
+import audioop
 import httpx
+
+
+# Kokoro-FastAPI emits PCM at this rate; Twilio expects this rate.
+_KOKORO_SAMPLE_RATE = 24000
+_TWILIO_SAMPLE_RATE = 8000
+_SAMPLE_WIDTH = 2  # 16-bit
+
+
+def pcm24k_to_twilio_mulaw(pcm_24k_s16le: bytes) -> bytes:
+    """Resample 24 kHz s16le PCM mono → μ-law 8 kHz mono.
+
+    Exposed (and named) so the pipeline can call it directly when needed,
+    and so unit tests can exercise the transform without HTTP.
+    """
+    pcm_8k, _state = audioop.ratecv(
+        pcm_24k_s16le, _SAMPLE_WIDTH, 1, _KOKORO_SAMPLE_RATE, _TWILIO_SAMPLE_RATE, None
+    )
+    return audioop.lin2ulaw(pcm_8k, _SAMPLE_WIDTH)
 
 
 class TTSAdapter:
     _shared_client: httpx.AsyncClient | None = None
     _client_lock = asyncio.Lock()
 
-    def __init__(self, base_url: str, voice: str = "af") -> None:
+    def __init__(self, base_url: str, voice: str = "af_heart") -> None:
         self.base_url = base_url.rstrip("/")
         self.voice = voice
 
@@ -34,8 +77,14 @@ class TTSAdapter:
     async def synthesize(self, text: str) -> bytes:
         client = await self._client()
         res = await client.post(
-            f"{self.base_url}/v1/audio/synthesize",
-            json={"text": text, "voice": self.voice, "format": "pcm_16000"},
+            f"{self.base_url}/v1/audio/speech",
+            json={
+                "model": "kokoro",
+                "input": text,
+                "voice": self.voice,
+                "response_format": "pcm",
+                "stream": False,
+            },
         )
         res.raise_for_status()
-        return res.content
+        return pcm24k_to_twilio_mulaw(res.content)


### PR DESCRIPTION
## Summary

Six PR-#41 follow-up defects surfaced when running `bin/diagnose-voice.sh` against a real local-voice stack (whisper + kokoro + bridge) for the first time. All previously hidden because every existing test mocked the HTTP layer; nothing exercised the real upstream services.

## Defects fixed

**Bridge — TTS adapter (`infra/pipecat-bridge/tts_adapter.py`)**
- `/v1/audio/synthesize` is fictional on Kokoro-FastAPI → switch to `/v1/audio/speech` (OpenAI-compat) with the right body shape (`model`, `input`, `voice`, `response_format`, `stream`).
- Default voice `"af"` doesn't exist → use upstream default `"af_heart"`.
- Kokoro returns 24 kHz s16le PCM, but `pipecat.provider.ts` already assumes the bridge emits μ-law 8 kHz. Added `audioop.ratecv` + `lin2ulaw` so bytes are Twilio-ready and the existing TS contract is honored.
- Mocked test now pins the request shape and the 6× resample/companding ratio. New `test_tts_live.py` runs against a real Kokoro when `KOKORO_BASE_URL` is set — this is the contract test that would have caught all three issues.

**Compose (`docker-compose.prod.yml`)**
- Whisper + Kokoro healthchecks called `wget` which neither slim image ships → containers stayed permanently in `starting`, blocking `pipecat-bridge`'s `depends_on`. Switched whisper to a python3 stdlib probe and kokoro to `curl`.
- `ghcr.io/remsky/kokoro-fastapi:latest` is anonymous-fetch unauthorized (401). Replaced `image:` with `build:` against a new `infra/kokoro/Dockerfile` that clones the upstream public repo at a pinned commit and runs their CPU build.
- Default `WHISPER_MODEL=Systran/faster-whisper-large-v3-turbo` is now HF-gated (401) → switched the default to `Systran/faster-whisper-small`, with a comment for operators who want to opt into the larger model.

**Diagnostic (`bin/diagnose-voice.sh`)**
- `docker compose ... ps -q` ran without `-p`, so services started under any non-default project name reported `not running` indistinguishably from truly missing. Now reads `$COMPOSE_PROJECT_NAME` and passes `-p`.
- JWT mint required `npm i jsonwebtoken` with no install step documented. Replaced with a Python 3 stdlib HMAC-SHA256 mint — no extra deps.
- New `$BRIDGE_HOST_PORT` knob for stacks that publish 8400 on a non-default host port.

## Verification

- `pytest infra/pipecat-bridge/`: **25/25** passing (was 24, +1 direct unit test for the resample helper)
- `npm test` in `backend/`: **1896/1896** passing
- `bin/diagnose-voice.sh` against the rebuilt stack returned a complete STT→LLM→TTS roundtrip — `92918` μ-law bytes (~11.6 s @ 8 kHz)

## Test plan

- [ ] Pull this branch, `cp .env.example .env` and fill in `BRIDGE_JWT_SECRET`
- [ ] `docker compose -f docker-compose.prod.yml --profile local-voice up -d --build` (first build is ~10–15 min on CPU; Kokoro weights bake into the image)
- [ ] Wait for all four services to report healthy (no manual nudges needed)
- [ ] `BRIDGE_JWT_SECRET=$(grep BRIDGE_JWT_SECRET .env | cut -d= -f2) bash bin/diagnose-voice.sh` → see `transcript_complete` JSON with `audioBytes > 8000`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes six contract issues in the local voice stack to enable a clean STT→LLM→TTS roundtrip. TTS now targets Kokoro’s OpenAI-compatible endpoint and outputs Twilio-ready μ-law; compose healthchecks/builds are fixed, and the diagnostic script is project-aware and drops Node deps.

- **Bug Fixes**
  - TTS adapter: switch to `/v1/audio/speech` with `{"model","input","voice","response_format","stream"}`; default `voice` to `"af_heart"`; transcode 24 kHz PCM to 8 kHz μ-law using `audioop`; add unit and optional live contract tests (`KOKORO_BASE_URL`).
  - Compose: replace `wget` healthchecks (use Python `urllib` for Whisper, `curl` for Kokoro); build Kokoro from `infra/kokoro/Dockerfile` at a pinned upstream commit; set default `WHISPER_MODEL` to `Systran/faster-whisper-small` to avoid HF gating.
  - Diagnostic: pass `-p` via `$COMPOSE_PROJECT_NAME`; mint JWT with Python stdlib HMAC-SHA256 (no `jsonwebtoken`); support `$BRIDGE_HOST_PORT`.

<sup>Written for commit b2c1e3e336f8c89f79f6a07ce45fffacbbc186fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * TTS now uses OpenAI-compatible audio endpoint with improved audio processing (resampling and format conversion for better compatibility).

* **Bug Fixes**
  * Improved container health checks for better reliability and startup stability.
  * Enhanced diagnostic tooling with configurable settings and better endpoint testing.

* **Tests**
  * Added comprehensive test coverage for TTS audio processing and live synthesis validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->