### PR TITLE
refactor(voice): make Twilio creds reloadable from IntegrationConnection (issue #44, backend)

### DIFF
--- a/backend/src/__tests__/integration/voice-intake.integration.test.ts
+++ b/backend/src/__tests__/integration/voice-intake.integration.test.ts
@@ -33,6 +33,9 @@ interface TestServices {
   tenantResolver: {
     resolveTenantByDID: ReturnType<typeof vi.fn>;
   };
+  twilioVoiceProvider: {
+    getAuthToken: () => string | null;
+  };
 }
 
 const buildApp = async (): Promise<FastifyInstance> => {
@@ -45,6 +48,13 @@ const buildApp = async (): Promise<FastifyInstance> => {
     },
     tenantResolver: {
       resolveTenantByDID: vi.fn().mockResolvedValue('t1'),
+    },
+    // Auth-token gating in voice-intake routes now reads from the
+    // provider (DB → env fallback). Integration tests don't have a DB,
+    // so just return null — non-prod NODE_ENV in vitest skips signature
+    // verification with a warning, matching pre-refactor behavior.
+    twilioVoiceProvider: {
+      getAuthToken: () => null,
     },
   };
   (app as unknown as { services: TestServices }).services = services;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -204,15 +204,27 @@ async function main(): Promise<void> {
       logger.info('Voice intake media-stream WebSocket route registered');
     }
 
-    // Twilio Media Stream WebSocket (for voice dial-in)
-    if (app.services.twilioVoiceService && config.OPENAI_API_KEY) {
+    // Twilio Media Stream WebSocket (for voice dial-in).
+    //
+    // Note: this WS route is mounted at boot from the provider's *current*
+    // service. If the operator later configures Twilio via the integrations
+    // UI, the /api/meetings/:id/voice-join endpoint picks up the new creds
+    // immediately (it reads from `twilioVoiceProvider.getCurrent()` per
+    // request). However the audio bridge below is still bound to the boot
+    // snapshot — the OpenAI client is constructed at mount time and the
+    // dispatcher map is sealed once the server starts listening. Adding
+    // dynamic re-mount on settings change is tracked as follow-up to
+    // issue #44 (the WS dispatcher needs a per-connection lookup, not a
+    // static handler reference).
+    const twilioVoiceServiceForWs = app.services.twilioVoiceProvider.getCurrent();
+    if (twilioVoiceServiceForWs && config.OPENAI_API_KEY) {
       const twilioWss = setupTwilioMediaStreamWebSocket({
-        twilioVoiceService: app.services.twilioVoiceService,
+        twilioVoiceService: twilioVoiceServiceForWs,
         openaiApiKey: config.OPENAI_API_KEY,
       });
       wsRoutes.set('/media-stream/', twilioWss);
       logger.info('Twilio Media Stream WebSocket route registered (using OpenAI Realtime)');
-    } else if (app.services.twilioVoiceService && !config.OPENAI_API_KEY) {
+    } else if (twilioVoiceServiceForWs && !config.OPENAI_API_KEY) {
       logger.warn('Twilio service available but OPENAI_API_KEY not set - voice bot disabled');
     }
 

--- a/backend/src/lib/di-container.ts
+++ b/backend/src/lib/di-container.ts
@@ -93,6 +93,7 @@ import { TranscriptBufferService } from '../services/meeting/transcript-buffer.s
 
 // Twilio Voice (dial-in voice bot)
 import { TwilioVoiceService } from '../services/voice/twilio-voice.service.js';
+import { TwilioVoiceProvider } from '../services/voice/twilio-voice-provider.js';
 
 // Engagement lifecycle
 import { EngagementService } from '../services/engagement/engagement.service.js';
@@ -349,8 +350,18 @@ export interface Services {
   // Model registry — per-tenant provider credential + model config storage
   modelRegistry: ModelRegistryService;
 
-  // Twilio Voice (dial-in voice bot)
-  twilioVoiceService: TwilioVoiceService | null;  // null if Twilio not configured
+  // Twilio Voice (dial-in voice bot).
+  //
+  // `twilioVoiceProvider` is the source of truth — it reads creds from the
+  // IntegrationConnection table per tenant and rebuilds the underlying
+  // service when settings change. Callers should prefer
+  // `twilioVoiceProvider.getCurrent()` over the legacy `twilioVoiceService`
+  // field, which is populated once at boot and goes stale after a settings
+  // save until the next process restart. The legacy field is kept so older
+  // callers don't break during the transition; new code should use the
+  // provider directly.
+  twilioVoiceProvider: TwilioVoiceProvider;
+  twilioVoiceService: TwilioVoiceService | null;  // legacy: stale after settings reload
 
   // Transcript buffering (batches real-time chunks)
   transcriptBuffer: TranscriptBufferService;
@@ -726,6 +737,59 @@ export async function setupDependencies(app: FastifyInstance): Promise<void> {
   // Notion: internal integration token (Bearer). We verify the token, then
   // opportunistically list accessible targets so the wizard can show the
   // target picker in one round-trip. Token prefix must be `secret_` or `ntn_`.
+  // Twilio tester — exec-friendly error messages because this is the
+  // exact failure path a non-dev consumer hits when they paste a wrong SID
+  // or token. We hit the Account API endpoint directly rather than dragging
+  // in the full twilio SDK at boot, keeping startup lean.
+  integrationConnectionService.registerTester('twilio', async (creds) => {
+    const accountSid = String(creds.twilioAccountSid ?? '').trim();
+    const authToken = String(creds.twilioAuthToken ?? '').trim();
+    const phoneNumber = String(creds.twilioPhoneNumber ?? '').trim();
+    if (!accountSid || !authToken) {
+      return { ok: false, error: 'Both the Account SID and Auth Token are required.' };
+    }
+    if (!accountSid.startsWith('AC')) {
+      return {
+        ok: false,
+        error: 'That does not look like a Twilio Account SID — it should start with "AC".',
+      };
+    }
+    try {
+      const auth = Buffer.from(`${accountSid}:${authToken}`).toString('base64');
+      const res = await fetch(
+        `https://api.twilio.com/2010-04-01/Accounts/${encodeURIComponent(accountSid)}.json`,
+        { headers: { Authorization: `Basic ${auth}` } },
+      );
+      if (!res.ok) {
+        return {
+          ok: false,
+          error:
+            res.status === 401
+              ? 'Twilio rejected the Auth Token. Double-check you copied the full token from the console.'
+              : `Twilio replied ${res.status}. Verify the Account SID is the one shown on the Twilio dashboard.`,
+        };
+      }
+      const account = (await res.json()) as {
+        friendly_name?: string;
+        status?: string;
+      };
+      return {
+        ok: true,
+        metadata: {
+          friendlyName: account.friendly_name ?? accountSid,
+          accountStatus: account.status ?? 'unknown',
+          phoneNumber: phoneNumber || undefined,
+        },
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        error:
+          'Could not reach api.twilio.com. Check this server has outbound HTTPS access.',
+      };
+    }
+  });
+
   integrationConnectionService.registerTester('notion', async (creds) => {
     const apiKey = String(creds.apiKey ?? '').trim();
     if (!apiKey) return { ok: false, error: 'Paste your Notion integration secret first.' };
@@ -870,25 +934,28 @@ export async function setupDependencies(app: FastifyInstance): Promise<void> {
   logger.debug('Business services initialized');
 
   // ==========================================================================
-  // STEP 6.6: Create Twilio Voice service (for dial-in voice bot)
+  // STEP 6.6: Create Twilio Voice provider (for dial-in voice bot)
   // ==========================================================================
-  const twilioVoiceService = (
-    config.TWILIO_ACCOUNT_SID &&
-    config.TWILIO_AUTH_TOKEN &&
-    config.TWILIO_PHONE_NUMBER &&
-    config.WEBHOOK_BASE_URL
-  )
-    ? new TwilioVoiceService({
-        accountSid: config.TWILIO_ACCOUNT_SID,
-        authToken: config.TWILIO_AUTH_TOKEN,
-        phoneNumber: config.TWILIO_PHONE_NUMBER,
-        webhookBaseUrl: config.WEBHOOK_BASE_URL,
-        redis,
-      })
-    : null;
+  // Single-tenant self-hosted: the default tenant's IntegrationConnection
+  // row is the canonical Twilio cred source. If no row exists, the provider
+  // falls back to env vars (TWILIO_*, WEBHOOK_BASE_URL) so existing
+  // file-based deployments keep working unchanged. See issue #44.
+  const twilioVoiceProvider = new TwilioVoiceProvider({
+    tenantId: 'default',
+    integrationConnectionService,
+    envCreds: {
+      TWILIO_ACCOUNT_SID: config.TWILIO_ACCOUNT_SID,
+      TWILIO_AUTH_TOKEN: config.TWILIO_AUTH_TOKEN,
+      TWILIO_PHONE_NUMBER: config.TWILIO_PHONE_NUMBER,
+      WEBHOOK_BASE_URL: config.WEBHOOK_BASE_URL,
+    },
+    redis,
+  });
+  await twilioVoiceProvider.reload();
+  const twilioVoiceService = twilioVoiceProvider.getCurrent();
 
   if (!twilioVoiceService) {
-    logger.warn('TwilioVoiceService disabled (Twilio credentials or WEBHOOK_BASE_URL not configured)');
+    logger.warn('TwilioVoiceService disabled — no creds in IntegrationConnection or env. Configure via the integrations UI.');
   } else {
     // Reconcile any calls that were active before a server restart
     await twilioVoiceService.reconcileOnStartup();
@@ -1444,6 +1511,7 @@ export async function setupDependencies(app: FastifyInstance): Promise<void> {
     })(),
     modelRegistry: new ModelRegistryService(rlsPrisma),
     queueService,
+    twilioVoiceProvider,
     twilioVoiceService,
     transcriptBuffer,
     engagementService,

--- a/backend/src/lib/di-container.ts
+++ b/backend/src/lib/di-container.ts
@@ -1759,9 +1759,13 @@ export async function setupDependencies(app: FastifyInstance): Promise<void> {
   app.addHook('onClose', async () => {
     logger.info('Closing connections and stopping services...');
 
-    // End all active Twilio calls
-    if (twilioVoiceService) {
-      await twilioVoiceService.endAllCalls();
+    // End all active Twilio calls — read the live service from the
+    // provider, not the boot-time `twilioVoiceService` snapshot. If creds
+    // were rotated mid-process via the integrations UI, calls placed on
+    // the new service instance would otherwise leak past shutdown.
+    const liveTwilio = twilioVoiceProvider.getCurrent();
+    if (liveTwilio) {
+      await liveTwilio.endAllCalls();
     }
 
     // Close all SSE connections and stop heartbeat

--- a/backend/src/routes/integrations.routes.ts
+++ b/backend/src/routes/integrations.routes.ts
@@ -121,8 +121,20 @@ export async function integrationRoutes(fastify: FastifyInstance): Promise<void>
     // intake signature verification. Reload it so the freshly saved creds
     // take effect without a backend restart — this is the whole point of
     // moving Twilio off env-first config (issue #44).
+    //
+    // Wrap in try/catch: a reload failure should not turn a successful
+    // DB write into a 500. Worst case the operator restarts the backend
+    // (or hits the test endpoint, which forces a re-read) and creds
+    // still take effect.
     if (name === 'twilio') {
-      await fastify.services.twilioVoiceProvider.reload();
+      try {
+        await fastify.services.twilioVoiceProvider.reload();
+      } catch (err) {
+        logger.error(
+          { tenantId, err: (err as Error).message },
+          'Twilio provider reload failed after connect — creds saved, restart to activate',
+        );
+      }
     }
 
     logger.info('Integration connected via wizard', { tenantId, name, userId });
@@ -165,7 +177,14 @@ export async function integrationRoutes(fastify: FastifyInstance): Promise<void>
     // connection. Without this, an exec who clicked Disconnect would still
     // see calls being placed/answered until the next backend restart.
     if (name === 'twilio') {
-      await fastify.services.twilioVoiceProvider.reload();
+      try {
+        await fastify.services.twilioVoiceProvider.reload();
+      } catch (err) {
+        logger.error(
+          { tenantId, err: (err as Error).message },
+          'Twilio provider reload failed after disconnect — DB row removed, restart to fully clear in-memory service',
+        );
+      }
     }
     return reply.send({ success: true });
   });

--- a/backend/src/routes/integrations.routes.ts
+++ b/backend/src/routes/integrations.routes.ts
@@ -130,8 +130,13 @@ export async function integrationRoutes(fastify: FastifyInstance): Promise<void>
       try {
         await fastify.services.twilioVoiceProvider.reload();
       } catch (err) {
+        // Deliberately do NOT log err.message — Twilio auth errors can
+        // surface the token in the exception text, and CodeQL flags
+        // `err.message` here as js/clear-text-logging. The error class
+        // is enough signal to investigate; full detail can be obtained
+        // by reproducing locally with DEBUG=1.
         logger.error(
-          { tenantId, err: (err as Error).message },
+          { tenantId, errorType: (err as Error).constructor?.name ?? 'Error' },
           'Twilio provider reload failed after connect — creds saved, restart to activate',
         );
       }
@@ -180,8 +185,9 @@ export async function integrationRoutes(fastify: FastifyInstance): Promise<void>
       try {
         await fastify.services.twilioVoiceProvider.reload();
       } catch (err) {
+        // See connect handler — same rationale, no err.message in logs.
         logger.error(
-          { tenantId, err: (err as Error).message },
+          { tenantId, errorType: (err as Error).constructor?.name ?? 'Error' },
           'Twilio provider reload failed after disconnect — DB row removed, restart to fully clear in-memory service',
         );
       }

--- a/backend/src/routes/integrations.routes.ts
+++ b/backend/src/routes/integrations.routes.ts
@@ -117,6 +117,14 @@ export async function integrationRoutes(fastify: FastifyInstance): Promise<void>
       connectedBy: userId,
     });
 
+    // Twilio is read by a long-lived provider for voice dial-in + voice
+    // intake signature verification. Reload it so the freshly saved creds
+    // take effect without a backend restart — this is the whole point of
+    // moving Twilio off env-first config (issue #44).
+    if (name === 'twilio') {
+      await fastify.services.twilioVoiceProvider.reload();
+    }
+
     logger.info('Integration connected via wizard', { tenantId, name, userId });
     return reply.send({ success: true, data: connection });
   });
@@ -151,6 +159,14 @@ export async function integrationRoutes(fastify: FastifyInstance): Promise<void>
     }
     const tenantId = (request as FastifyRequest & { tenantId: string }).tenantId;
     await fastify.services.integrationConnectionService.disconnect(tenantId, name);
+
+    // Mirror of the /connect handler — clear the live provider so subsequent
+    // voice calls return 503 instead of using stale creds from the previous
+    // connection. Without this, an exec who clicked Disconnect would still
+    // see calls being placed/answered until the next backend restart.
+    if (name === 'twilio') {
+      await fastify.services.twilioVoiceProvider.reload();
+    }
     return reply.send({ success: true });
   });
 }

--- a/backend/src/routes/meetings.routes.ts
+++ b/backend/src/routes/meetings.routes.ts
@@ -455,7 +455,11 @@ export async function meetingRoutes(fastify: FastifyInstance): Promise<void> {
       const tenantId = (request as FastifyRequest & { tenantId: string }).tenantId;
       const { id } = request.params;
 
-      if (!fastify.services.twilioVoiceService) {
+      // Read the live service from the provider — settings saves rebuild
+      // it without a restart, so the boot-time `twilioVoiceService` field
+      // would be stale here.
+      const twilioVoiceService = fastify.services.twilioVoiceProvider.getCurrent();
+      if (!twilioVoiceService) {
         return reply.status(503).send({
           success: false,
           error: {
@@ -493,7 +497,7 @@ export async function meetingRoutes(fastify: FastifyInstance): Promise<void> {
       });
 
       try {
-        const callSid = await fastify.services.twilioVoiceService.dialIntoMeeting(
+        const callSid = await twilioVoiceService.dialIntoMeeting(
           id,
           body.dialInNumber,
           body.accessCode,
@@ -542,10 +546,11 @@ export async function meetingRoutes(fastify: FastifyInstance): Promise<void> {
         });
       }
 
-      if (fastify.services.twilioVoiceService) {
+      const twilioVoiceServiceForLeave = fastify.services.twilioVoiceProvider.getCurrent();
+      if (twilioVoiceServiceForLeave) {
         const callSid = (meeting.metadata as Record<string, unknown>)?.callSid as string;
         if (callSid) {
-          await fastify.services.twilioVoiceService.hangup(callSid);
+          await twilioVoiceServiceForLeave.hangup(callSid);
         }
       }
 

--- a/backend/src/routes/meetings.routes.ts
+++ b/backend/src/routes/meetings.routes.ts
@@ -546,12 +546,27 @@ export async function meetingRoutes(fastify: FastifyInstance): Promise<void> {
         });
       }
 
+      // If a callSid was recorded, the call exists at Twilio's edge and we
+      // must actually hangup before claiming the meeting completed.
+      // Marking it complete without hanging up leaves a billed call live
+      // — the orange-bar bug CodeRabbit flagged.
+      const callSid = (meeting.metadata as Record<string, unknown>)?.callSid as string | undefined;
       const twilioVoiceServiceForLeave = fastify.services.twilioVoiceProvider.getCurrent();
-      if (twilioVoiceServiceForLeave) {
-        const callSid = (meeting.metadata as Record<string, unknown>)?.callSid as string;
-        if (callSid) {
-          await twilioVoiceServiceForLeave.hangup(callSid);
+      if (callSid) {
+        if (!twilioVoiceServiceForLeave) {
+          logger.error(
+            { meetingId: id, callSid },
+            'voice-leave: Twilio provider unavailable but callSid is recorded — refusing to mark meeting completed (live call would be orphaned)',
+          );
+          return reply.status(503).send({
+            success: false,
+            error: {
+              code: 'SERVICE_UNAVAILABLE',
+              message: 'Twilio is not configured; cannot end the active call. Reconnect Twilio in Settings → Integrations and try again.',
+            },
+          });
         }
+        await twilioVoiceServiceForLeave.hangup(callSid);
       }
 
       await fastify.services.prisma.meeting.update({

--- a/backend/src/routes/webhooks/__tests__/twilio-inbound.routes.test.ts
+++ b/backend/src/routes/webhooks/__tests__/twilio-inbound.routes.test.ts
@@ -34,6 +34,13 @@ const buildApp = async (overrides?: {
     tenantResolver: {
       resolveTenantByDID: vi.fn().mockResolvedValue(overrides?.tenantId ?? 't1'),
     },
+    // Mirror what TwilioVoiceProvider does in production: read the auth
+    // token from IntegrationConnection first, env fallback. Tests don't
+    // touch the DB, so the provider just defers to env — matches the
+    // existing "TWILIO_AUTH_TOKEN gating" assertions in the suite below.
+    twilioVoiceProvider: {
+      getAuthToken: () => config.TWILIO_AUTH_TOKEN ?? null,
+    },
   };
   await app.register(twilioInboundRoutes, { prefix: '/webhooks/twilio/voice' });
   await app.ready();

--- a/backend/src/routes/webhooks/twilio-inbound.routes.ts
+++ b/backend/src/routes/webhooks/twilio-inbound.routes.ts
@@ -73,6 +73,15 @@ interface ServicesShape {
       ctx: { fromNumber: string; toNumber: string; acceptedAt: number },
     ): void;
   };
+  /**
+   * Live source-of-truth for the Twilio auth token used by signature
+   * verification. Reads from `IntegrationConnection` first, env fallback.
+   * Returning null = unconfigured, in which case production rejects unsigned
+   * requests; non-prod allows them through with a warning (dev install path).
+   */
+  twilioVoiceProvider: {
+    getAuthToken(): string | null;
+  };
 }
 
 /**
@@ -119,65 +128,68 @@ function hangupTwiML(message: string): string {
 }
 
 /**
- * Pre-handler: verify the X-Twilio-Signature header against TWILIO_AUTH_TOKEN.
+ * Pre-handler factory: verify the X-Twilio-Signature header against the
+ * current Twilio auth token (DB → env fallback, via the provider).
+ *
+ * Built per-route as a closure so the auth-token getter is captured
+ * lazily — every call re-reads from the provider, picking up wizard
+ * settings changes without a backend restart.
  *
  * Bypass policy:
- *   - In production with no token set, REJECT with 503 — a forged unsigned
- *     webhook would otherwise trigger meeting creation / PIN prompts. A
- *     production self-hoster who isn't using voice can simply leave the
- *     route unmounted (callerAuth gates inbound calls separately); but if
- *     the route IS mounted, missing token = misconfiguration, not "skip".
- *   - In dev/test with no token set, allow through with a warning so a
- *     first-time installer can complete the wizard against ngrok without
- *     copying the auth token first. Mirrors the dev-only bypass in
+ *   - In production with no token, REJECT with 503 — a forged unsigned
+ *     webhook would otherwise trigger meeting creation / PIN prompts.
+ *   - In dev/test with no token, allow through with a warning so a
+ *     first-time installer can complete the wizard against a tunnel
+ *     before pasting the auth token. Mirrors the dev-only bypass in
  *     `routes/twilio.routes.ts::verifyTwilioWebhook`.
  */
-const verifyTwilioSignature: preHandlerHookHandler = async (
-  request: FastifyRequest,
-  reply: FastifyReply,
-) => {
-  const authToken = config.TWILIO_AUTH_TOKEN;
-  if (!authToken) {
-    if (config.NODE_ENV === 'production') {
-      logger.error(
-        { url: request.url },
-        'TWILIO_AUTH_TOKEN missing in production — rejecting unsigned voice webhook',
+function makeVerifyTwilioSignature(
+  getAuthToken: () => string | null,
+): preHandlerHookHandler {
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    const authToken = getAuthToken();
+    if (!authToken) {
+      if (config.NODE_ENV === 'production') {
+        logger.error(
+          { url: request.url },
+          'No Twilio auth token (DB or env) in production — rejecting unsigned voice webhook',
+        );
+        return reply.status(503).send({ error: 'voice intake not configured' });
+      }
+      logger.warn(
+        { url: request.url, nodeEnv: config.NODE_ENV },
+        'Twilio auth token unset — bypassing signature verification (non-production only). Configure Twilio in the integrations UI before exposing this endpoint to the public internet.',
       );
-      return reply.status(503).send({ error: 'voice intake not configured' });
+      return; // Allow through (dev/test only).
     }
-    logger.warn(
-      { url: request.url, nodeEnv: config.NODE_ENV },
-      'TWILIO_AUTH_TOKEN unset — bypassing signature verification (non-production only). Set TWILIO_AUTH_TOKEN before exposing this endpoint to the public internet.',
-    );
-    return; // Allow through (dev/test only).
-  }
 
-  const signature = request.headers['x-twilio-signature'];
-  const signatureStr = Array.isArray(signature) ? signature[0] : signature;
-  if (!signatureStr) {
-    logger.warn({ url: request.url }, 'Missing X-Twilio-Signature header');
-    return reply.status(401).send({ error: 'Missing Twilio signature' });
-  }
+    const signature = request.headers['x-twilio-signature'];
+    const signatureStr = Array.isArray(signature) ? signature[0] : signature;
+    if (!signatureStr) {
+      logger.warn({ url: request.url }, 'Missing X-Twilio-Signature header');
+      return reply.status(401).send({ error: 'Missing Twilio signature' });
+    }
 
-  // Reconstruct the URL Twilio used to sign the request. Honour the
-  // X-Forwarded-Proto/Host headers because reverse proxies (Caddy, Cloudflare
-  // Tunnel) terminate TLS and the inner Fastify only sees `http`.
-  const protoHeader = request.headers['x-forwarded-proto'];
-  const proto = (Array.isArray(protoHeader) ? protoHeader[0] : protoHeader) ?? 'https';
-  const hostHeader = request.headers['host'];
-  const host = (Array.isArray(hostHeader) ? hostHeader[0] : hostHeader) ?? 'localhost';
-  const url = `${proto}://${host}${request.url}`;
-  const params =
-    typeof request.body === 'object' && request.body !== null
-      ? (request.body as Record<string, string>)
-      : {};
+    // Reconstruct the URL Twilio used to sign the request. Honour the
+    // X-Forwarded-Proto/Host headers because reverse proxies (Caddy, Cloudflare
+    // Tunnel) terminate TLS and the inner Fastify only sees `http`.
+    const protoHeader = request.headers['x-forwarded-proto'];
+    const proto = (Array.isArray(protoHeader) ? protoHeader[0] : protoHeader) ?? 'https';
+    const hostHeader = request.headers['host'];
+    const host = (Array.isArray(hostHeader) ? hostHeader[0] : hostHeader) ?? 'localhost';
+    const url = `${proto}://${host}${request.url}`;
+    const params =
+      typeof request.body === 'object' && request.body !== null
+        ? (request.body as Record<string, string>)
+        : {};
 
-  const valid = twilio.validateRequest(authToken, signatureStr, url, params);
-  if (!valid) {
-    logger.warn({ url }, 'Invalid Twilio signature');
-    return reply.status(401).send({ error: 'Invalid Twilio signature' });
-  }
-};
+    const valid = twilio.validateRequest(authToken, signatureStr, url, params);
+    if (!valid) {
+      logger.warn({ url }, 'Invalid Twilio signature');
+      return reply.status(401).send({ error: 'Invalid Twilio signature' });
+    }
+  };
+}
 
 /**
  * Per-route rate-limit config: 60 requests/minute/IP. Matches the guidance
@@ -196,6 +208,9 @@ const inboundRateLimitConfig = {
 
 export async function twilioInboundRoutes(fastify: FastifyInstance): Promise<void> {
   const services = (fastify as unknown as { services: ServicesShape }).services;
+  const verifyTwilioSignature = makeVerifyTwilioSignature(() =>
+    services.twilioVoiceProvider.getAuthToken(),
+  );
 
   fastify.post(
     '/inbound',

--- a/backend/src/services/voice/__tests__/twilio-voice-provider.test.ts
+++ b/backend/src/services/voice/__tests__/twilio-voice-provider.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for TwilioVoiceProvider — the lazy, reloadable wrapper around
+ * TwilioVoiceService that reads creds from IntegrationConnection (DB) instead
+ * of process.env at boot.
+ *
+ * The contract this pins:
+ *   - getCurrent() returns null when no creds anywhere (env or DB)
+ *   - getCurrent() returns a working service when DB has creds
+ *   - getCurrent() falls back to env when DB has nothing (backwards compat)
+ *   - reload() rebuilds the service when creds change in DB
+ *   - reload() preserves the existing service when creds are unchanged
+ *     (so in-flight call-tracking state isn't lost on irrelevant settings saves)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TwilioVoiceProvider } from '../twilio-voice-provider.js';
+import { TwilioVoiceService } from '../twilio-voice.service.js';
+
+// Mock the twilio SDK so we don't hit network
+vi.mock('twilio', () => {
+  const mockClient = { calls: { create: vi.fn() }, calls_get: vi.fn() };
+  const Twilio = vi.fn(() => mockClient);
+  return { default: Twilio, Twilio };
+});
+
+interface FakeIntegrationConnectionService {
+  getDecryptedCredentials: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeIcs(initialCreds: Record<string, unknown> | null = null): FakeIntegrationConnectionService {
+  return {
+    getDecryptedCredentials: vi.fn().mockResolvedValue(initialCreds),
+  };
+}
+
+const ENV_DEFAULTS = {
+  TWILIO_ACCOUNT_SID: 'AC_env_sid',
+  TWILIO_AUTH_TOKEN: 'env_token',
+  TWILIO_PHONE_NUMBER: '+15551111111',
+  WEBHOOK_BASE_URL: 'https://env-host.example.com',
+};
+
+const DB_CREDS = {
+  twilioAccountSid: 'AC_db_sid',
+  twilioAuthToken: 'db_token',
+  twilioPhoneNumber: '+15552222222',
+  webhookBaseUrl: 'https://db-host.example.com',
+};
+
+describe('TwilioVoiceProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when neither DB nor env has creds', async () => {
+    const ics = makeFakeIcs(null);
+    const provider = new TwilioVoiceProvider({
+      tenantId: 'default',
+      integrationConnectionService: ics as never,
+      envCreds: {},
+    });
+    await provider.reload();
+    expect(provider.getCurrent()).toBeNull();
+  });
+
+  it('builds from env when DB has no creds (backwards compat for self-hosters)', async () => {
+    const ics = makeFakeIcs(null);
+    const provider = new TwilioVoiceProvider({
+      tenantId: 'default',
+      integrationConnectionService: ics as never,
+      envCreds: ENV_DEFAULTS,
+    });
+    await provider.reload();
+    const svc = provider.getCurrent();
+    expect(svc).toBeInstanceOf(TwilioVoiceService);
+    expect(svc?.isAvailable()).toBe(true);
+  });
+
+  it('prefers DB creds over env when both are present', async () => {
+    const ics = makeFakeIcs(DB_CREDS);
+    const provider = new TwilioVoiceProvider({
+      tenantId: 'default',
+      integrationConnectionService: ics as never,
+      envCreds: ENV_DEFAULTS,
+    });
+    await provider.reload();
+    const svc = provider.getCurrent();
+    expect(svc).toBeInstanceOf(TwilioVoiceService);
+    // Phone number should come from DB, not env. Check via the public getter
+    // we'll add as part of this slice.
+    expect(svc?.getPhoneNumber()).toBe('+15552222222');
+  });
+
+  it('rebuilds the service when DB creds change between reload() calls', async () => {
+    const ics = makeFakeIcs(DB_CREDS);
+    const provider = new TwilioVoiceProvider({
+      tenantId: 'default',
+      integrationConnectionService: ics as never,
+      envCreds: {},
+    });
+    await provider.reload();
+    const first = provider.getCurrent();
+    expect(first?.getPhoneNumber()).toBe('+15552222222');
+
+    // Simulate operator updating creds in the integrations UI
+    ics.getDecryptedCredentials.mockResolvedValueOnce({
+      ...DB_CREDS,
+      twilioPhoneNumber: '+15553333333',
+    });
+    await provider.reload();
+    const second = provider.getCurrent();
+    expect(second?.getPhoneNumber()).toBe('+15553333333');
+    expect(second).not.toBe(first); // new instance built
+  });
+
+  it('preserves the existing instance when creds are unchanged on reload', async () => {
+    const ics = makeFakeIcs(DB_CREDS);
+    const provider = new TwilioVoiceProvider({
+      tenantId: 'default',
+      integrationConnectionService: ics as never,
+      envCreds: {},
+    });
+    await provider.reload();
+    const first = provider.getCurrent();
+    await provider.reload(); // no change to creds
+    const second = provider.getCurrent();
+    expect(second).toBe(first); // same instance — in-flight calls survive
+  });
+
+  it('exposes the auth token for inbound signature verification', async () => {
+    const ics = makeFakeIcs(DB_CREDS);
+    const provider = new TwilioVoiceProvider({
+      tenantId: 'default',
+      integrationConnectionService: ics as never,
+      envCreds: ENV_DEFAULTS,
+    });
+    await provider.reload();
+    // DB creds win — that's the expected ordering.
+    expect(provider.getAuthToken()).toBe('db_token');
+  });
+
+  it('falls back to env auth token when DB has no creds', async () => {
+    const ics = makeFakeIcs(null);
+    const provider = new TwilioVoiceProvider({
+      tenantId: 'default',
+      integrationConnectionService: ics as never,
+      envCreds: ENV_DEFAULTS,
+    });
+    await provider.reload();
+    expect(provider.getAuthToken()).toBe('env_token');
+  });
+
+  it('returns null auth token when neither DB nor env has creds', async () => {
+    const ics = makeFakeIcs(null);
+    const provider = new TwilioVoiceProvider({
+      tenantId: 'default',
+      integrationConnectionService: ics as never,
+      envCreds: {},
+    });
+    await provider.reload();
+    expect(provider.getAuthToken()).toBeNull();
+  });
+
+  it('clears the service when DB creds are removed (operator disconnected Twilio)', async () => {
+    const ics = makeFakeIcs(DB_CREDS);
+    const provider = new TwilioVoiceProvider({
+      tenantId: 'default',
+      integrationConnectionService: ics as never,
+      envCreds: {},
+    });
+    await provider.reload();
+    expect(provider.getCurrent()).not.toBeNull();
+
+    ics.getDecryptedCredentials.mockResolvedValueOnce(null);
+    await provider.reload();
+    expect(provider.getCurrent()).toBeNull();
+  });
+});

--- a/backend/src/services/voice/__tests__/twilio-voice-provider.test.ts
+++ b/backend/src/services/voice/__tests__/twilio-voice-provider.test.ts
@@ -160,6 +160,28 @@ describe('TwilioVoiceProvider', () => {
     expect(provider.getAuthToken()).toBeNull();
   });
 
+  it('rejects empty-string DB creds and falls back to env (Cubic P2 on PR #45)', async () => {
+    // Simulate a partially-filled wizard form persisting blank fields.
+    const partialDbCreds = {
+      twilioAccountSid: 'AC_db_sid',
+      twilioAuthToken: '',
+      twilioPhoneNumber: '+15552222222',
+      webhookBaseUrl: 'https://db-host.example.com',
+    };
+    const ics = makeFakeIcs(partialDbCreds);
+    const provider = new TwilioVoiceProvider({
+      tenantId: 'default',
+      integrationConnectionService: ics as never,
+      envCreds: ENV_DEFAULTS,
+    });
+    await provider.reload();
+    const svc = provider.getCurrent();
+    // Should fall back to env, not build a broken service from the
+    // empty-token row.
+    expect(svc?.getPhoneNumber()).toBe(ENV_DEFAULTS.TWILIO_PHONE_NUMBER);
+    expect(provider.getAuthToken()).toBe(ENV_DEFAULTS.TWILIO_AUTH_TOKEN);
+  });
+
   it('clears the service when DB creds are removed (operator disconnected Twilio)', async () => {
     const ics = makeFakeIcs(DB_CREDS);
     const provider = new TwilioVoiceProvider({

--- a/backend/src/services/voice/twilio-voice-provider.ts
+++ b/backend/src/services/voice/twilio-voice-provider.ts
@@ -1,0 +1,200 @@
+/**
+ * Lazy, reloadable wrapper around TwilioVoiceService.
+ *
+ * Why this exists
+ * ───────────────
+ * TwilioVoiceService used to be instantiated once at boot from `process.env`.
+ * That made the wizard a lie: a non-dev consumer could paste Twilio creds
+ * into the integrations page, but the service was already built (or
+ * permanently disabled) and never re-read the new values. See issue #44.
+ *
+ * The provider:
+ *   - Reads creds from `IntegrationConnection` (DB) for the configured tenant
+ *   - Falls back to env vars if the DB has no entry (preserves existing
+ *     self-hosters who set their creds in `.env` at install time)
+ *   - Rebuilds the underlying service only when creds actually change, so
+ *     in-flight call tracking (activeCalls, callsByMeeting maps inside
+ *     TwilioVoiceService) survives unrelated settings saves
+ *   - Returns null when no creds are available — callers must handle this
+ *     and 503 the request rather than crash
+ *
+ * Settings UI flow
+ * ────────────────
+ * After IntegrationConnectionService.connect('twilio', {...}) returns, the
+ * settings route should call provider.reload() so subsequent /voice-join
+ * and /webhooks/twilio/* calls see the new creds without a restart.
+ */
+
+import { createChildLogger } from '../../lib/logger.js';
+import type { Redis } from 'ioredis';
+import {
+  TwilioVoiceService,
+  type TwilioVoiceConfig,
+} from './twilio-voice.service.js';
+
+const logger = createChildLogger({ service: 'TwilioVoiceProvider' });
+
+/**
+ * Subset of IntegrationConnectionService that the provider needs.
+ * Defined as an interface so tests can pass a fake without dragging in
+ * the encryption helper or a real Prisma client.
+ */
+export interface IntegrationConnectionLookup {
+  getDecryptedCredentials(
+    tenantId: string,
+    name: 'twilio',
+  ): Promise<Record<string, unknown> | null>;
+}
+
+/**
+ * Env-style fallback creds. Optional fields so tests can construct a
+ * provider with zero env wiring; fields use the Workforce0 env-var names
+ * (TWILIO_ACCOUNT_SID etc.) but are stripped of the prefix for clarity.
+ */
+export interface TwilioEnvFallback {
+  TWILIO_ACCOUNT_SID?: string;
+  TWILIO_AUTH_TOKEN?: string;
+  TWILIO_PHONE_NUMBER?: string;
+  WEBHOOK_BASE_URL?: string;
+}
+
+export interface TwilioVoiceProviderOptions {
+  /**
+   * The tenant whose Twilio creds this provider serves. Single-tenant
+   * self-hosted installs use 'default'. Per-tenant SaaS deployments would
+   * instantiate one provider per tenant — out of scope for the current
+   * single-org product.
+   */
+  tenantId: string;
+  integrationConnectionService: IntegrationConnectionLookup;
+  envCreds: TwilioEnvFallback;
+  /**
+   * Optional Redis used by TwilioVoiceService for crash-recovery state.
+   * Forwarded into each rebuilt instance.
+   */
+  redis?: Redis | null;
+}
+
+/**
+ * Compact identifier the provider uses to detect cred drift between
+ * reload() calls. Build it from the four config-affecting fields.
+ *
+ * We deliberately don't hash — storing the auth token in a hash would just
+ * obscure a log line. The provider instance is process-local; if you can
+ * read its memory you can already read process.env.
+ */
+function fingerprint(c: TwilioVoiceConfig | null): string {
+  if (!c) return '';
+  return [c.accountSid, c.authToken, c.phoneNumber, c.webhookBaseUrl].join('|');
+}
+
+function pickFromDb(creds: Record<string, unknown> | null): TwilioVoiceConfig | null {
+  if (!creds) return null;
+  // Field names match what IntegrationConnectionService stores when the
+  // settings UI saves Twilio creds (see settings.routes.ts twilio test
+  // handler — uses twilioAccountSid / twilioAuthToken). webhookBaseUrl is
+  // tenant-scoped here because each tenant might run behind a different
+  // public hostname (e.g. their own Cloudflare tunnel).
+  const accountSid = creds.twilioAccountSid;
+  const authToken = creds.twilioAuthToken;
+  const phoneNumber = creds.twilioPhoneNumber;
+  const webhookBaseUrl = creds.webhookBaseUrl;
+  if (
+    typeof accountSid !== 'string' ||
+    typeof authToken !== 'string' ||
+    typeof phoneNumber !== 'string' ||
+    typeof webhookBaseUrl !== 'string'
+  ) {
+    return null;
+  }
+  return { accountSid, authToken, phoneNumber, webhookBaseUrl };
+}
+
+function pickFromEnv(env: TwilioEnvFallback): TwilioVoiceConfig | null {
+  const { TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER, WEBHOOK_BASE_URL } = env;
+  if (!TWILIO_ACCOUNT_SID || !TWILIO_AUTH_TOKEN || !TWILIO_PHONE_NUMBER || !WEBHOOK_BASE_URL) {
+    return null;
+  }
+  return {
+    accountSid: TWILIO_ACCOUNT_SID,
+    authToken: TWILIO_AUTH_TOKEN,
+    phoneNumber: TWILIO_PHONE_NUMBER,
+    webhookBaseUrl: WEBHOOK_BASE_URL,
+  };
+}
+
+export class TwilioVoiceProvider {
+  private readonly opts: TwilioVoiceProviderOptions;
+  private current: TwilioVoiceService | null = null;
+  private currentFingerprint = '';
+
+  constructor(opts: TwilioVoiceProviderOptions) {
+    this.opts = opts;
+  }
+
+  /**
+   * Re-read creds from the integration connection (or env fallback) and
+   * rebuild the underlying service if they've changed. Safe to call from
+   * boot, settings save handlers, or background reconcile jobs.
+   *
+   * Resolves a boolean indicating whether the underlying service changed
+   * identity (useful for log "Twilio reloaded" markers).
+   */
+  async reload(): Promise<boolean> {
+    const fromDb = await this.opts.integrationConnectionService
+      .getDecryptedCredentials(this.opts.tenantId, 'twilio')
+      .catch((err) => {
+        logger.error(
+          { err: (err as Error).message, tenantId: this.opts.tenantId },
+          'Failed to read Twilio creds from IntegrationConnection — falling back to env',
+        );
+        return null;
+      });
+
+    const next = pickFromDb(fromDb) ?? pickFromEnv(this.opts.envCreds);
+    const nextFp = fingerprint(next);
+
+    if (nextFp === this.currentFingerprint) {
+      return false; // no change — keep existing instance + its activeCalls
+    }
+
+    this.current = next
+      ? new TwilioVoiceService({ ...next, redis: this.opts.redis ?? undefined })
+      : null;
+    this.currentFingerprint = nextFp;
+    logger.info(
+      {
+        tenantId: this.opts.tenantId,
+        configured: this.current !== null,
+        source: fromDb ? 'integration_connection' : 'env_fallback',
+      },
+      'Twilio voice service reloaded',
+    );
+    return true;
+  }
+
+  /**
+   * Returns the current service or null if unconfigured. Synchronous —
+   * callers should have called reload() at boot or after a settings change.
+   * The cost of the async path was deliberately pushed into reload() so
+   * route handlers don't pay it on every Twilio webhook hit.
+   */
+  getCurrent(): TwilioVoiceService | null {
+    return this.current;
+  }
+
+  /**
+   * Auth token for inbound webhook signature verification.
+   *
+   * The inbound voice-intake route (`/webhooks/twilio/voice/inbound`) calls
+   * `twilio.validateRequest(authToken, signature, url, params)` per request.
+   * That used to read `process.env.TWILIO_AUTH_TOKEN` directly, which made
+   * the wizard's "rotate Twilio creds" flow a lie until the next restart.
+   *
+   * Falls back to env when the provider has no instance — for self-hosters
+   * who set creds in `.env` and never bothered with the integrations UI.
+   */
+  getAuthToken(): string | null {
+    return this.current?.getAuthToken() ?? this.opts.envCreds.TWILIO_AUTH_TOKEN ?? null;
+  }
+}

--- a/backend/src/services/voice/twilio-voice-provider.ts
+++ b/backend/src/services/voice/twilio-voice-provider.ts
@@ -95,19 +95,27 @@ function pickFromDb(creds: Record<string, unknown> | null): TwilioVoiceConfig | 
   // handler — uses twilioAccountSid / twilioAuthToken). webhookBaseUrl is
   // tenant-scoped here because each tenant might run behind a different
   // public hostname (e.g. their own Cloudflare tunnel).
+  //
+  // Reject empty strings the same way pickFromEnv does — the integrations
+  // UI may persist a partially-filled form, and a service built from
+  // empty creds will 401 on every Twilio API call instead of failing
+  // closed at boot.
   const accountSid = creds.twilioAccountSid;
   const authToken = creds.twilioAuthToken;
   const phoneNumber = creds.twilioPhoneNumber;
   const webhookBaseUrl = creds.webhookBaseUrl;
-  if (
-    typeof accountSid !== 'string' ||
-    typeof authToken !== 'string' ||
-    typeof phoneNumber !== 'string' ||
-    typeof webhookBaseUrl !== 'string'
-  ) {
-    return null;
-  }
-  return { accountSid, authToken, phoneNumber, webhookBaseUrl };
+  const allFilled =
+    typeof accountSid === 'string' && accountSid.length > 0 &&
+    typeof authToken === 'string' && authToken.length > 0 &&
+    typeof phoneNumber === 'string' && phoneNumber.length > 0 &&
+    typeof webhookBaseUrl === 'string' && webhookBaseUrl.length > 0;
+  if (!allFilled) return null;
+  return {
+    accountSid: accountSid as string,
+    authToken: authToken as string,
+    phoneNumber: phoneNumber as string,
+    webhookBaseUrl: webhookBaseUrl as string,
+  };
 }
 
 function pickFromEnv(env: TwilioEnvFallback): TwilioVoiceConfig | null {
@@ -151,7 +159,15 @@ export class TwilioVoiceProvider {
         return null;
       });
 
-    const next = pickFromDb(fromDb) ?? pickFromEnv(this.opts.envCreds);
+    // Resolve in two steps so the log can report which branch actually
+    // produced the config — DB record may exist but be partially filled,
+    // in which case we silently fall through to env. Reporting "source:
+    // integration_connection" in that case would be a lie (and confused
+    // a Cubic review on PR #45).
+    const fromDbConfig = pickFromDb(fromDb);
+    const next = fromDbConfig ?? pickFromEnv(this.opts.envCreds);
+    const source: 'integration_connection' | 'env_fallback' | 'none' =
+      fromDbConfig ? 'integration_connection' : next ? 'env_fallback' : 'none';
     const nextFp = fingerprint(next);
 
     if (nextFp === this.currentFingerprint) {
@@ -166,7 +182,7 @@ export class TwilioVoiceProvider {
       {
         tenantId: this.opts.tenantId,
         configured: this.current !== null,
-        source: fromDb ? 'integration_connection' : 'env_fallback',
+        source,
       },
       'Twilio voice service reloaded',
     );

--- a/backend/src/services/voice/twilio-voice.service.ts
+++ b/backend/src/services/voice/twilio-voice.service.ts
@@ -124,6 +124,36 @@ export class TwilioVoiceService {
   }
 
   /**
+   * Phone number this instance is configured to dial from. Read by the
+   * provider for cred-change detection (so the wrapper can decide whether
+   * a settings save actually requires rebuilding the service).
+   */
+  getPhoneNumber(): string {
+    return this.config.phoneNumber;
+  }
+
+  /**
+   * Auth token used for both Twilio API client auth and inbound webhook
+   * signature verification (`twilio.validateRequest`). Voice-intake routes
+   * read this through the provider so the wizard can rotate the token
+   * without a backend restart.
+   *
+   * Treat the return value as sensitive — do not log it.
+   */
+  getAuthToken(): string {
+    return this.config.authToken;
+  }
+
+  /**
+   * Webhook base URL this instance was configured with. Same rationale as
+   * getPhoneNumber — the provider needs to inspect config without poking
+   * at private fields.
+   */
+  getWebhookBaseUrl(): string {
+    return this.config.webhookBaseUrl;
+  }
+
+  /**
    * Check if the service is properly configured.
    */
   isAvailable(): boolean {


### PR DESCRIPTION
## Summary

First of two PRs addressing issue #44 — voice services were env-first
while every other integration (Jira, Google Chat, GitHub, Slack) was
DB-backed, making the wizard a lie for non-dev consumers.

This PR is the **backend half**: Twilio creds are now read from
`IntegrationConnection`, the wizard's `/api/integrations/twilio/connect`
endpoint actually takes effect, and settings saves propagate to the
running service without a restart.

The frontend Twilio form is the follow-up PR.

## What changed

**New: `TwilioVoiceProvider` (`services/voice/twilio-voice-provider.ts`)**
- Wraps `TwilioVoiceService`, reads creds from `IntegrationConnection`
  first, env fallback for existing self-hosters
- Rebuilds the underlying service only when creds actually change
  (preserves in-flight `activeCalls` state across unrelated saves)
- Unit-tested: env-only / DB-only / DB-overrides-env / reload identity
  preserved on no-op / disconnected → service cleared / auth-token
  getter for inbound signature verification

**`TwilioVoiceService`** — read-only accessors `getPhoneNumber()`,
`getWebhookBaseUrl()`, `getAuthToken()` so the provider doesn't poke
private fields.

**DI container** — provider replaces direct env-based instantiation;
legacy `services.twilioVoiceService` still populated for backwards compat
(boot snapshot, won't reflect later reloads). Twilio integration tester
registered alongside Jira / Notion / Linear testers.

**Consumer updates**
- `meetings.routes.ts` `/voice-join` + `/voice-leave` use
  `provider.getCurrent()` per request
- `webhooks/twilio-inbound.routes.ts` (PR #41 voice intake) reads
  auth token via provider per request — wizard can rotate creds
  without restart
- `integrations.routes.ts` `/connect` and DELETE call `provider.reload()`
  when name === 'twilio'

## Scope cuts (noted inline + tracked as follow-ups)

- **WebSocket dispatcher for the dial-in audio bridge** is still gated
  on `OPENAI_API_KEY` at boot — mounting it lazily requires a
  per-connection lookup in the dispatcher map, not a static handler
  reference. Out of scope here.
- **`VoiceDialInModal` opened without `meetingId`** on the meetings
  page — distinct UI bug surfaced during testing, separate issue.
- **Frontend Twilio integration form** — the consumer-facing UX is in
  the follow-up PR; this PR opens the API path.
- **`WEBHOOK_BASE_URL` ↔ `WEBHOOK_BASE_HOST` consolidation** — out of
  scope, tracked in #44 acceptance criteria.

## Verification

- New tests: **9/9** in `twilio-voice-provider.test.ts`
- Full backend suite: **1905/1905** across 139 files
- `tsc --noEmit`: clean

## Test plan

- [ ] Pull this branch
- [ ] `cp .env.example .env` and leave Twilio vars empty
- [ ] `docker compose up -d` — backend boots without "TwilioVoiceService disabled" hard-fail (logs warning instead)
- [ ] `curl -X POST http://localhost:3000/api/integrations/twilio/connect -H 'Content-Type: application/json' --cookie 'wf0_access=…' --data '{"credentials":{"twilioAccountSid":"AC…","twilioAuthToken":"…","twilioPhoneNumber":"+1…"}}'` — succeeds, returns connection metadata
- [ ] `curl http://localhost:3000/health` is unchanged
- [ ] Subsequent `/api/meetings/:id/voice-join` no longer 503s for Twilio reasons (still 503s on OpenAI Realtime if OPENAI_API_KEY is unset — separate gate)
- [ ] `curl -X DELETE http://localhost:3000/api/integrations/twilio` — provider clears, next voice-join 503s with "not configured"

Refs: #44

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Twilio Voice credentials reloadable from `IntegrationConnection` (DB-first, env fallback) so the wizard configures voice without a backend restart. Backend half of issue #44: immediate connect/disconnect, safe token rotation, and sanitized error logging.

- **New Features**
  - Added `TwilioVoiceProvider` to load creds from `IntegrationConnection`, rebuild only when creds change, and expose the live auth token; DI registers `twilioVoiceProvider` and keeps a legacy `twilioVoiceService` boot snapshot.
  - Meetings `voice-join/leave` and Twilio inbound webhooks read the current service/token via the provider on each request; `/api/integrations/twilio` connect/disconnect calls `provider.reload()`. Media Stream WS mounts at boot from `provider.getCurrent()`; dynamic remount is a follow-up in #44.
  - Added a Twilio creds tester that hits the Account API and returns clear, user-friendly errors.

- **Bug Fixes**
  - `voice-leave` now hangs up a recorded `callSid`; if Twilio is disconnected mid-call, it returns 503 instead of marking the meeting complete.
  - Shutdown ends calls using the provider’s live instance, not the stale boot snapshot.
  - Provider ignores empty-string DB fields and correctly reports whether config came from DB, env, or neither; `provider.reload()` after connect/disconnect is wrapped in try/catch so a reload failure doesn’t 500 a successful DB write.
  - Removed `err.message` from reload-failure logs to avoid leaking secrets; log error type only.

<sup>Written for commit 3c31b654fcdec3d05efd5ed457a6925f0696f89f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Twilio credentials can reload at runtime and take effect immediately for dial‑in, hangup and webhook handling.
  * Integration tester now validates Twilio credentials and returns friendly success metadata.

* **Behavior Changes**
  * Webhooks check the live Twilio auth token per request, preserving production/dev gating.
  * WebSocket audio bridge remains bound to startup credentials (changes don’t affect existing bridges).

* **Bug Fixes**
  * Connect/disconnect flows avoid using stale in‑memory creds; calls return 503 if service unavailable.

* **Tests**
  * Added tests validating provider reloads, credential precedence, webhook gating and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->