### PR TITLE
feat(frontend): Twilio Voice integration wizard (issue #44, frontend half)

### DIFF
--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -25,7 +25,7 @@ import {
 } from "lucide-react";
 
 interface CatalogEntry {
-  name: IntegrationName | "gdrive" | "twilio" | "gdocs" | "asana" | "salesforce";
+  name: IntegrationName | "gdrive" | "gdocs" | "asana" | "salesforce";
   label: string;
   blurb: string;
   status: "available" | "coming_soon";
@@ -144,6 +144,7 @@ export default function IntegrationsPage() {
                           "linear",
                           "notion",
                           "gchat",
+                          "twilio",
                         ];
                         if (canWizard.includes(entry.name as IntegrationName)) {
                           setWizardOpen(entry.name as IntegrationName);

--- a/frontend/src/components/integration-wizard.tsx
+++ b/frontend/src/components/integration-wizard.tsx
@@ -35,7 +35,8 @@ export type IntegrationName =
   | "github"
   | "linear"
   | "notion"
-  | "gchat";
+  | "gchat"
+  | "twilio";
 
 interface FieldSpec {
   key: string;
@@ -235,6 +236,56 @@ const INTEGRATION_SPECS: Record<IntegrationName, IntegrationSpec> = {
             key: "webhookUrl",
             label: "Webhook URL",
             placeholder: "https://chat.googleapis.com/v1/spaces/...",
+            type: "password",
+          },
+        ],
+      },
+    },
+  },
+  // Field `key`s here MUST match the credential keys the backend's
+  // Twilio tester reads (see backend/src/lib/di-container.ts —
+  // `integrationConnectionService.registerTester('twilio', …)`):
+  // twilioAccountSid, twilioAuthToken, twilioPhoneNumber.
+  twilio: {
+    title: "Connect Twilio Voice",
+    tokenPageUrl: "https://console.twilio.com",
+    tokenPageLabel: "Open Twilio console",
+    steps: {
+      identifier: {
+        heading: "What's your Twilio account?",
+        subtitle: "Find these in your Twilio console — they take 30 seconds to copy.",
+        fields: [
+          {
+            key: "twilioAccountSid",
+            label: "Account SID",
+            placeholder: "AC...",
+            type: "text",
+            helper: "Top-right of console.twilio.com — starts with AC.",
+          },
+          {
+            key: "twilioPhoneNumber",
+            label: "Twilio phone number",
+            placeholder: "+15551234567",
+            type: "text",
+            helper:
+              "The number people will dial to reach you (or that the AI will dial out from). Use E.164 format with the country code.",
+          },
+        ],
+      },
+      token: {
+        heading: "Paste your Auth Token",
+        subtitle:
+          "This lets Workforce0 receive inbound calls and place outbound dial-ins. Stored encrypted; never logged.",
+        instructions: [
+          "Open the Twilio console — the link is the button below.",
+          'Find "Auth Token" right under your Account SID, click "View".',
+          "Copy the full token and paste it here.",
+        ],
+        fields: [
+          {
+            key: "twilioAuthToken",
+            label: "Auth Token",
+            placeholder: "32-character hex string",
             type: "password",
           },
         ],


### PR DESCRIPTION
## Summary

Frontend half of issue #44 — the form a non-dev consumer actually
clicks to configure Twilio. Stacks on top of PR #45 (backend); merge
**after** that one lands.

## What changed

**`integration-wizard.tsx`** — adds `twilio` to `INTEGRATION_SPECS`:

| Step | Heading | Fields |
|---|---|---|
| 1 (identifier) | "What's your Twilio account?" | `twilioAccountSid` (text), `twilioPhoneNumber` (text, E.164) |
| 2 (token) | "Paste your Auth Token" | `twilioAuthToken` (password) |
| 3 | Test result + success state | (existing wizard machinery) |

Field `key`s match what the backend tester reads (`backend/src/lib/di-container.ts` from PR #45). Comment in the spec calls out the dependency so a future schema drift gets caught at the same place.

**`settings/integrations/page.tsx`** — adds `"twilio"` to the
`canWizard` list so clicking "Connect" on the Twilio card opens the
wizard. Trims redundant `"twilio"` literal from `CatalogEntry.name`
since `IntegrationName` already covers it.

## UX choices worth flagging

- Account SID and phone number are **visible inputs** (not passwords). Account SID is public-ish (it's in URLs) and phone number is the user's own number — hiding either creates copy-paste anxiety with no security benefit.
- Auth Token uses the existing password input + eye-toggle from `IntegrationWizard`.
- "Open Twilio console" button on step 2 deep-links to `console.twilio.com` where SID + token are right at the top.
- Sub-heading on step 2: *"This lets Workforce0 receive inbound calls and place outbound dial-ins. Stored encrypted; never logged."* — addresses the "what is this for?" + "is this safe?" questions an exec would have without forcing them to read docs.

## Verification

- `tsc --noEmit`: clean
- `npm test`: **97/97 actual tests pass**
- Two pre-existing test files (`components.test.tsx`, `pages-smoke.test.tsx`) fail on `main` and on this branch the same way — `lucide-react` mocking issue in `sidebar.tsx`. Confirmed not introduced by this PR; will file separately if no existing issue covers it.

## Test plan

After PR #45 merges:
- [ ] Pull this branch
- [ ] `docker compose up -d --build frontend backend`
- [ ] Sign up via wizard, finish onboarding
- [ ] Visit `/settings/integrations`
- [ ] Click "Connect" on the Twilio Voice card
- [ ] Step 1 — paste a fake Account SID + fake phone number, click Next
- [ ] Step 2 — paste a fake Auth Token, click "Test connection"
- [ ] Expect: 400 with a clear "That does not look like a Twilio Account SID" or "Twilio rejected the Auth Token" message (from the backend tester)
- [ ] Repeat with **real** creds — expect the wizard to flip to the success step
- [ ] `curl http://localhost:3000/api/integrations | jq` — expect `name: "twilio", status: "connected"`
- [ ] Make a real outbound call via the meetings page — works without restarting backend

Refs: #44 (closes the wizard half)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Twilio Voice setup wizard so users can connect their Twilio account and number from Settings. Frontend half of issue #44; uses the backend tester to validate credentials.

- **New Features**
  - Added `twilio` to the Integration Wizard: Step 1 (Account SID + phone number), Step 2 (Auth Token) with a direct link to the Twilio console.
  - Field keys match the backend tester (`twilioAccountSid`, `twilioAuthToken`, `twilioPhoneNumber`); enabled the Twilio wizard from the Integrations page (`canWizard`) and removed the redundant `"twilio"` from the `CatalogEntry.name` union.

<sup>Written for commit eb5970c9ea08ded689e45e4eda3e12cc495559e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Twilio integration is now available in integrations settings. Connect your Twilio account through the guided integration wizard, which securely collects your account identifier, phone number, and authentication credentials for seamless platform integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->