### PR TITLE
feat(tour): guided onboarding tour — Phase 1 (5 pages)

### DIFF
--- a/backend/prisma/migrations/20260427000000_add_user_has_seen_tour/migration.sql
+++ b/backend/prisma/migrations/20260427000000_add_user_has_seen_tour/migration.sql
@@ -1,0 +1,6 @@
+-- Guided tour: track whether each user has completed (or dismissed) the
+-- onboarding tour. Default false so new users get the auto-tour on first
+-- login; existing users start at false too (one-time re-show is harmless
+-- and the StartTourButton can dismiss for power users).
+ALTER TABLE "users"
+  ADD COLUMN "hasSeenTour" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -190,6 +190,11 @@ model User {
   name         String
   role         String    @default("member") // owner, admin, member, viewer
   lastLoginAt  DateTime?
+  /// Set true when the user has completed (or explicitly dismissed) the
+  /// guided tour. Persisted server-side so re-login on a fresh browser
+  /// doesn't re-trigger the auto-tour. localStorage is used as a fast
+  /// client-side hint; this column is the source of truth.
+  hasSeenTour  Boolean   @default(false)
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 

--- a/backend/src/routes/__tests__/auth.routes.test.ts
+++ b/backend/src/routes/__tests__/auth.routes.test.ts
@@ -353,6 +353,11 @@ describe('Auth Routes', () => {
         name: 'Me Org',
         settings: { auth: { email: 'me@example.com', name: 'Me User' } },
       });
+      // /auth/me also reads the user row for hasSeenTour (PR #63).
+      // Mock it explicitly so the 401 user-not-found guard doesn't fire.
+      mockPrisma.user.findUnique.mockResolvedValue({
+        hasSeenTour: false,
+      });
 
       const res = await app.inject({
         method: 'GET', url: '/me',
@@ -364,6 +369,25 @@ describe('Auth Routes', () => {
       expect(body.data.email).toBe('me@example.com');
       expect(body.data.name).toBe('Me User');
       expect(body.data.organizationName).toBe('Me Org');
+      expect(body.data.hasSeenTour).toBe(false);
+    });
+
+    it('returns 401 when user row no longer exists (deleted account)', async () => {
+      const token = await getValidToken();
+      mockPrisma.tenant.findUnique.mockResolvedValue({
+        id: 'tenant-123',
+        name: 'Me Org',
+        settings: {},
+      });
+      mockPrisma.user.findUnique.mockResolvedValue(null);
+
+      const res = await app.inject({
+        method: 'GET', url: '/me',
+        headers: { authorization: `Bearer ${token}` },
+      });
+
+      expect(res.statusCode).toBe(401);
+      expect(res.json().error?.code).toBe('USER_NOT_FOUND');
     });
 
     it('returns 401 when no authorization header', async () => {

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -563,6 +563,15 @@ export async function authRoutes(fastify: FastifyInstance): Promise<void> {
       });
     }
 
+    // Look up `hasSeenTour` on the user row — drives the auto-tour
+    // gating in GuidedTour.tsx. Read here so /auth/me is the single
+    // authoritative bootstrap call and the frontend doesn't need a
+    // second roundtrip just for the tour flag.
+    const user = await prisma.user.findUnique({
+      where: { id: payload.userId as string },
+      select: { hasSeenTour: true },
+    });
+
     return reply.send({
       success: true,
       data: {
@@ -572,8 +581,45 @@ export async function authRoutes(fastify: FastifyInstance): Promise<void> {
         role: payload.role || 'owner',
         organizationName: tenant.name,
         tenantId: tenant.id,
+        hasSeenTour: user?.hasSeenTour ?? false,
       },
     });
+  });
+
+  /**
+   * POST /auth/me/tour-seen
+   *
+   * Mark the tour completed (or dismissed) for the current user. Idempotent —
+   * the frontend fires this on first auto-tour bootstrap and again on
+   * "Finish Tour" / "End Tour", and we don't care if it's set twice.
+   */
+  fastify.post('/me/tour-seen', async (request: FastifyRequest, reply: FastifyReply) => {
+    const authHeader = request.headers['authorization'];
+    const token = authHeader?.startsWith('Bearer ')
+      ? authHeader.replace('Bearer ', '')
+      : (request.cookies as Record<string, string> | undefined)?.['wf0_access'];
+
+    if (!token) {
+      return reply.status(401).send({
+        success: false,
+        error: { code: 'UNAUTHORIZED', message: 'Token required' },
+      });
+    }
+
+    const payload = verifyToken(token);
+    if (!payload) {
+      return reply.status(401).send({
+        success: false,
+        error: { code: 'INVALID_TOKEN', message: 'Invalid or expired token' },
+      });
+    }
+
+    await fastify.services.prisma.user.update({
+      where: { id: payload.userId as string },
+      data: { hasSeenTour: true },
+    });
+
+    return reply.send({ success: true });
   });
 
   /**

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -567,10 +567,21 @@ export async function authRoutes(fastify: FastifyInstance): Promise<void> {
     // gating in GuidedTour.tsx. Read here so /auth/me is the single
     // authoritative bootstrap call and the frontend doesn't need a
     // second roundtrip just for the tour flag.
+    //
+    // If the user row no longer exists (account deleted while a JWT is
+    // still valid) we 401 — silently returning hasSeenTour:false would
+    // let the deleted user's frontend keep operating against a tenant
+    // that no longer trusts them.
     const user = await prisma.user.findUnique({
       where: { id: payload.userId as string },
       select: { hasSeenTour: true },
     });
+    if (!user) {
+      return reply.status(401).send({
+        success: false,
+        error: { code: 'USER_NOT_FOUND', message: 'Account no longer exists' },
+      });
+    }
 
     return reply.send({
       success: true,
@@ -581,7 +592,7 @@ export async function authRoutes(fastify: FastifyInstance): Promise<void> {
         role: payload.role || 'owner',
         organizationName: tenant.name,
         tenantId: tenant.id,
-        hasSeenTour: user?.hasSeenTour ?? false,
+        hasSeenTour: user.hasSeenTour,
       },
     });
   });
@@ -592,35 +603,58 @@ export async function authRoutes(fastify: FastifyInstance): Promise<void> {
    * Mark the tour completed (or dismissed) for the current user. Idempotent —
    * the frontend fires this on first auto-tour bootstrap and again on
    * "Finish Tour" / "End Tour", and we don't care if it's set twice.
+   *
+   * Rate-limited (10/min/IP) because it writes to the user row on every
+   * call. CodeQL's js/missing-rate-limiting rule flagged the original;
+   * the limit is generous enough that the legitimate ~3 calls per
+   * tour-completion never hit it.
    */
-  fastify.post('/me/tour-seen', async (request: FastifyRequest, reply: FastifyReply) => {
-    const authHeader = request.headers['authorization'];
-    const token = authHeader?.startsWith('Bearer ')
-      ? authHeader.replace('Bearer ', '')
-      : (request.cookies as Record<string, string> | undefined)?.['wf0_access'];
+  fastify.post(
+    '/me/tour-seen',
+    {
+      config: {
+        rateLimit: { max: 10, timeWindow: '1 minute' },
+      },
+    },
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const authHeader = request.headers['authorization'];
+      const token = authHeader?.startsWith('Bearer ')
+        ? authHeader.replace('Bearer ', '')
+        : (request.cookies as Record<string, string> | undefined)?.[ACCESS_COOKIE];
 
-    if (!token) {
-      return reply.status(401).send({
-        success: false,
-        error: { code: 'UNAUTHORIZED', message: 'Token required' },
+      if (!token) {
+        return reply.status(401).send({
+          success: false,
+          error: { code: 'UNAUTHORIZED', message: 'Token required' },
+        });
+      }
+
+      const payload = verifyToken(token);
+      if (!payload) {
+        return reply.status(401).send({
+          success: false,
+          error: { code: 'INVALID_TOKEN', message: 'Invalid or expired token' },
+        });
+      }
+
+      // updateMany returns a count rather than throwing P2025 when the
+      // row is missing — turns the deleted-user case into a clean 404
+      // instead of an unhandled 500.
+      const result = await fastify.services.prisma.user.updateMany({
+        where: { id: payload.userId as string },
+        data: { hasSeenTour: true },
       });
-    }
 
-    const payload = verifyToken(token);
-    if (!payload) {
-      return reply.status(401).send({
-        success: false,
-        error: { code: 'INVALID_TOKEN', message: 'Invalid or expired token' },
-      });
-    }
+      if (result.count === 0) {
+        return reply.status(404).send({
+          success: false,
+          error: { code: 'USER_NOT_FOUND', message: 'Account no longer exists' },
+        });
+      }
 
-    await fastify.services.prisma.user.update({
-      where: { id: payload.userId as string },
-      data: { hasSeenTour: true },
-    });
-
-    return reply.send({ success: true });
-  });
+      return reply.send({ success: true });
+    },
+  );
 
   /**
    * GET /auth/invite/:token - Validate invitation token

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "driver.js": "^1.4.0",
         "lucide-react": "^0.564.0",
         "next": "16.2.3",
         "react": "19.2.3",
@@ -6443,6 +6444,12 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/driver.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.4.0.tgz",
+      "integrity": "sha512-Gm64jm6PmcU+si21sQhBrTAM1JvUrR0QhNmjkprNLxohOBzul9+pNHXgQaT9lW84gwg9GMLB3NZGuGolsz5uew==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "driver.js": "^1.4.0",
     "lucide-react": "^0.564.0",
     "next": "16.2.3",
     "react": "19.2.3",

--- a/frontend/src/app/(dashboard)/engagements/page.tsx
+++ b/frontend/src/app/(dashboard)/engagements/page.tsx
@@ -242,7 +242,7 @@ export default function EngagementsPage() {
       <Header title="Engagements" />
 
       <div className="max-w-5xl space-y-6 p-6 lg:p-8">
-        <div className="space-y-2">
+        <div data-tour="engagements-header" className="space-y-2">
           <h2 className="font-display text-3xl font-semibold tracking-[-0.025em] text-ink">
             Project Pipeline
           </h2>
@@ -251,7 +251,7 @@ export default function EngagementsPage() {
           </p>
         </div>
 
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <Tabs data-tour="engagements-list" value={activeTab} onValueChange={setActiveTab}>
           <TabsList className="mb-6">
             <TabsTrigger value="all">All</TabsTrigger>
             <TabsTrigger value="active">Active</TabsTrigger>

--- a/frontend/src/app/(dashboard)/layout.tsx
+++ b/frontend/src/app/(dashboard)/layout.tsx
@@ -8,6 +8,8 @@ import { AgentJobNotifier } from "@/components/agent-job-notifier";
 import { ProjectProvider } from "@/lib/project-context";
 import { BrandMark } from "@/components/brand-mark";
 import { Step0MigrationBanner } from "@/components/step0-migration-banner";
+import GuidedTour from "@/components/tour/GuidedTour";
+import StartTourButton from "@/components/tour/StartTourButton";
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -63,6 +65,15 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
             </svg>
           </button>
           <span className="ml-3 text-[15px] font-bold text-ink tracking-tight">Workforce0</span>
+          <div className="ml-auto">
+            <StartTourButton />
+          </div>
+        </div>
+        {/* Desktop tour-launcher row — sits flush right above the
+            content. The mobile launcher above lives in the existing
+            header bar to save vertical space on small screens. */}
+        <div className="hidden lg:flex justify-end items-center gap-2 px-6 pt-4">
+          <StartTourButton />
         </div>
         {/* Plan 3 Step 0: top-of-app migration banner for existing tenants
             who haven't yet seen the local-everything wizard. Renders null
@@ -74,6 +85,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
           {children}
         </div>
       </main>
+      <GuidedTour />
     </div>
     </ProjectProvider>
   );

--- a/frontend/src/app/(dashboard)/meetings/page.tsx
+++ b/frontend/src/app/(dashboard)/meetings/page.tsx
@@ -104,6 +104,7 @@ export default function MeetingsPage() {
   return (
     <div className="min-h-screen">
       <Header title="Meetings" />
+      <span data-tour="meetings-header" aria-hidden className="sr-only" />
 
       <div className="space-y-6 p-6 lg:p-8">
         {/* Actions bar */}
@@ -122,7 +123,7 @@ export default function MeetingsPage() {
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-2">
-            <Button variant="outline" onClick={() => setShowVoiceDialIn(true)}>
+            <Button data-tour="meetings-voice-dialin" variant="outline" onClick={() => setShowVoiceDialIn(true)}>
               <Phone className="h-4 w-4" />
               Voice Dial-In
             </Button>
@@ -131,6 +132,7 @@ export default function MeetingsPage() {
               Paste Transcript
             </Button>
             <Button
+              data-tour="meetings-upload"
               variant="accent"
               className="glow"
               onClick={() => setShowUpload(true)}

--- a/frontend/src/app/(dashboard)/meetings/page.tsx
+++ b/frontend/src/app/(dashboard)/meetings/page.tsx
@@ -104,11 +104,10 @@ export default function MeetingsPage() {
   return (
     <div className="min-h-screen">
       <Header title="Meetings" />
-      <span data-tour="meetings-header" aria-hidden className="sr-only" />
 
       <div className="space-y-6 p-6 lg:p-8">
         {/* Actions bar */}
-        <div className="flex flex-wrap items-center justify-between gap-4">
+        <div data-tour="meetings-header" className="flex flex-wrap items-center justify-between gap-4">
           <div className="relative w-full max-w-md flex-1">
             <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-faint" />
             <Input

--- a/frontend/src/app/(dashboard)/prds/page.tsx
+++ b/frontend/src/app/(dashboard)/prds/page.tsx
@@ -74,9 +74,8 @@ export default function PrdsPage() {
   return (
     <div className="min-h-screen">
       <Header title="Briefs" />
-      <span data-tour="prds-header" aria-hidden className="sr-only" />
 
-      <div data-tour="prds-create" className="space-y-6 p-6 lg:p-8">
+      <div data-tour="prds-header" className="space-y-6 p-6 lg:p-8">
         {/* Needs Attention Banner */}
         {needsAttention.length > 0 && (
           <div className="flex items-center gap-3 rounded-[var(--radius-md)] border border-transparent border-gradient bg-accent-subtle/40 p-4 shadow-[var(--shadow-card)]">
@@ -101,7 +100,7 @@ export default function PrdsPage() {
         )}
 
         {/* Filters */}
-        <div className="flex flex-wrap items-center justify-between gap-4">
+        <div data-tour="prds-create" className="flex flex-wrap items-center justify-between gap-4">
           <Tabs value={filter} onValueChange={setFilter}>
             <TabsList>
               <TabsTrigger value="all">All</TabsTrigger>

--- a/frontend/src/app/(dashboard)/prds/page.tsx
+++ b/frontend/src/app/(dashboard)/prds/page.tsx
@@ -74,8 +74,9 @@ export default function PrdsPage() {
   return (
     <div className="min-h-screen">
       <Header title="Briefs" />
+      <span data-tour="prds-header" aria-hidden className="sr-only" />
 
-      <div className="space-y-6 p-6 lg:p-8">
+      <div data-tour="prds-create" className="space-y-6 p-6 lg:p-8">
         {/* Needs Attention Banner */}
         {needsAttention.length > 0 && (
           <div className="flex items-center gap-3 rounded-[var(--radius-md)] border border-transparent border-gradient bg-accent-subtle/40 p-4 shadow-[var(--shadow-card)]">

--- a/frontend/src/app/(dashboard)/settings/integrations/page.tsx
+++ b/frontend/src/app/(dashboard)/settings/integrations/page.tsx
@@ -83,7 +83,7 @@ export default function IntegrationsPage() {
     <>
       <Header title="Integrations" />
       <div className="mx-auto max-w-7xl space-y-8 px-6 py-8">
-        <header className="flex flex-wrap items-end justify-between gap-4">
+        <header data-tour="integrations-header" className="flex flex-wrap items-end justify-between gap-4">
           <div className="space-y-2">
             <h1 className="font-display text-3xl font-semibold tracking-[-0.025em] text-ink">
               Integrations
@@ -207,6 +207,7 @@ function IntegrationCard({
   const isConnected = !comingSoon && status === "connected";
   return (
     <div
+      data-tour={`integration-card-${entry.name}`}
       className={`card-interactive relative flex flex-col gap-3 rounded-[var(--radius-lg)] border bg-surface p-5 shadow-[var(--shadow-card)] transition-all duration-[160ms] ${
         isConnected
           ? "border-transparent border-gradient"

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -131,7 +131,7 @@ export function Sidebar({ mobileOpen, onMobileClose }: SidebarProps) {
       </div>
 
       {/* Navigation */}
-      <nav aria-label="Main navigation" className="flex-1 px-3 py-2 space-y-0.5 overflow-y-auto">
+      <nav data-tour="sidebar-nav" aria-label="Main navigation" className="flex-1 px-3 py-2 space-y-0.5 overflow-y-auto">
         {navigation.map((item) => {
           // Pick the deepest matching nav entry as active so parents (e.g. /settings)
           // don't also light up when on a child route (e.g. /settings/system-status).

--- a/frontend/src/components/tour/GuidedTour.tsx
+++ b/frontend/src/components/tour/GuidedTour.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+/**
+ * Guided tour orchestrator. Mounted once in the dashboard layout.
+ *
+ * Behavior
+ * ────────
+ * - First sign-in (no `hasSeenTour` server flag, no localStorage seen
+ *   marker) → auto-starts the tour and pushes the user to the first
+ *   route in TOUR_ROUTE_ORDER.
+ * - Per-route step list driven via driver.js. When a route's steps
+ *   complete, advances to the next route automatically.
+ * - User can pause via the "Explore on your own" button (injected as
+ *   HTML in step descriptions). A floating banner offers Resume / End.
+ * - "End Tour" or finishing the last route's last step calls
+ *   `api.markTourSeen()` so the auto-tour doesn't re-trigger on the
+ *   next session.
+ *
+ * Adapted from aether2.0's `components/tour/GuidedTour.tsx`. Auth API
+ * differs: aether uses `getStoredUser()`, workforce0 uses `getUser()`.
+ */
+import { useEffect, useState, useCallback, useRef, useMemo } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { driver, DriveStep } from "driver.js";
+import "driver.js/dist/driver.css";
+import "@/lib/tour/driver.css";
+import { getUser } from "@/lib/auth";
+import { api } from "@/lib/api";
+import {
+  getStepsForRoute,
+  getTourRouteOrder,
+  normalizeTourPath,
+  ROUTE_LABELS,
+  TOUR_KEY,
+  TOUR_PAUSED_KEY,
+  TOUR_SEEN_PREFIX,
+  TOUR_START_EVENT,
+  TOUR_PAUSE_EVENT,
+} from "@/lib/tour/tourSteps";
+
+function ResumeBanner({ onResume, onEnd }: { onResume: () => void; onEnd: () => void }) {
+  return (
+    <div className="tour-resume-banner" role="status" aria-live="polite">
+      <span>Tour paused — explore freely</span>
+      <button className="tour-resume-btn" onClick={onResume}>
+        Resume Tour
+      </button>
+      <button className="tour-end-btn" onClick={onEnd}>
+        End Tour
+      </button>
+    </div>
+  );
+}
+
+export default function GuidedTour() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const user = getUser();
+  // Tour is the same shape for everyone in Phase 1 — the admin/superadmin
+  // split is wired so Phase 2's admin-only pages can plug in without
+  // touching the orchestrator.
+  const isAdmin = user?.role === "admin" || user?.role === "owner";
+  const routeOrder = useMemo(() => getTourRouteOrder(isAdmin), [isAdmin]);
+  const [tourActive, setTourActive] = useState(false);
+  const [paused, setPaused] = useState(false);
+  const driverRef = useRef<ReturnType<typeof driver> | null>(null);
+  const hasAutoCheckedRef = useRef(false);
+
+  // Hydrate from localStorage on mount so a refresh mid-tour resumes
+  // instead of restarting from step 1.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (localStorage.getItem(TOUR_KEY) === "true") {
+      setTourActive(true);
+      setPaused(localStorage.getItem(TOUR_PAUSED_KEY) === "true");
+    }
+  }, []);
+
+  // First-login auto-start. Guarded against re-firing within a session
+  // and against running on auth pages.
+  useEffect(() => {
+    if (hasAutoCheckedRef.current) return;
+    if (!user?.email) return;
+    hasAutoCheckedRef.current = true;
+
+    const userKey = `${TOUR_SEEN_PREFIX}${user.email}`;
+    const seenLocal = localStorage.getItem(userKey) === "true";
+    // The /auth/me payload exposes `hasSeenTour` (added with the
+    // migration in this same PR). Cast through unknown because the
+    // public User type doesn't include it yet — we treat the field as
+    // optional so older cached user objects still work.
+    const seenServer =
+      (user as unknown as { hasSeenTour?: boolean }).hasSeenTour === true;
+    if (seenLocal || seenServer) return;
+    if (localStorage.getItem(TOUR_KEY) === "true") return;
+
+    const skipPaths = ["/login", "/signup", "/forgot-password", "/reset-password", "/onboarding"];
+    if (skipPaths.some((p) => pathname.startsWith(p))) return;
+
+    localStorage.setItem(userKey, "true");
+    api.markTourSeen().catch(() => {
+      // Server-side write is best-effort; the localStorage flag above
+      // already prevents re-trigger this session.
+    });
+    localStorage.setItem(TOUR_KEY, "true");
+    setTourActive(true);
+    if (normalizeTourPath(pathname) !== "/dashboard") {
+      router.push("/dashboard");
+    }
+  }, [user, pathname, router]);
+
+  // External "start tour" trigger from the header button.
+  useEffect(() => {
+    function handleStart() {
+      setPaused(false);
+      localStorage.removeItem(TOUR_PAUSED_KEY);
+      setTourActive(true);
+    }
+    window.addEventListener(TOUR_START_EVENT, handleStart);
+    return () => window.removeEventListener(TOUR_START_EVENT, handleStart);
+  }, []);
+
+  // External pause trigger from the "Explore on your own" button
+  // injected into step descriptions.
+  useEffect(() => {
+    function handlePause() {
+      if (driverRef.current) {
+        driverRef.current.destroy();
+        driverRef.current = null;
+      }
+      setPaused(true);
+      localStorage.setItem(TOUR_PAUSED_KEY, "true");
+    }
+    window.addEventListener(TOUR_PAUSE_EVENT, handlePause);
+    return () => window.removeEventListener(TOUR_PAUSE_EVENT, handlePause);
+  }, []);
+
+  // The actual driver.js loop. Re-runs on route change while the tour
+  // is active, picks up the next step list, advances to the next route
+  // when the user clicks "Continue to <Page>" on the last step.
+  useEffect(() => {
+    if (!tourActive || paused) return;
+
+    const baseSteps = getStepsForRoute(pathname);
+    if (!baseSteps || baseSteps.length === 0) return;
+
+    // 800 ms delay gives the new route's anchors time to mount before
+    // driver.js queries them. Without this, navigating in step
+    // sometimes lands on a "Element not found" stub.
+    const timer = setTimeout(() => {
+      const currentRouteIndex = routeOrder.indexOf(normalizeTourPath(pathname));
+      if (currentRouteIndex === -1) return;
+
+      const nextRoute = routeOrder[currentRouteIndex + 1];
+      const isLastRoute = !nextRoute;
+      const nextLabel = nextRoute
+        ? ROUTE_LABELS[nextRoute] || nextRoute.replace(/^\//, "") || "next"
+        : "";
+
+      const steps: DriveStep[] = baseSteps;
+
+      const d = driver({
+        showProgress: true,
+        animate: true,
+        allowClose: true,
+        overlayColor: "rgba(0, 0, 0, 0.55)",
+        stagePadding: 10,
+        stageRadius: 10,
+        nextBtnText: "Next",
+        prevBtnText: "Back",
+        doneBtnText: isLastRoute ? "Finish Tour" : `Continue to ${nextLabel}`,
+        onCloseClick: () => {
+          d.destroy();
+          driverRef.current = null;
+          setPaused(true);
+          localStorage.setItem(TOUR_PAUSED_KEY, "true");
+        },
+        onDestroyStarted: () => {
+          if (isLastRoute) {
+            // Tour fully completed — clear state + persist server-side.
+            localStorage.removeItem(TOUR_KEY);
+            localStorage.removeItem(TOUR_PAUSED_KEY);
+            if (user?.email) {
+              localStorage.setItem(`${TOUR_SEEN_PREFIX}${user.email}`, "true");
+            }
+            api.markTourSeen().catch(() => {});
+            setTourActive(false);
+            setPaused(false);
+            d.destroy();
+          } else {
+            d.destroy();
+            driverRef.current = null;
+            router.push(nextRoute);
+          }
+        },
+        steps,
+      });
+
+      driverRef.current = d;
+      d.drive();
+    }, 800);
+
+    return () => {
+      clearTimeout(timer);
+      if (driverRef.current) {
+        driverRef.current.destroy();
+        driverRef.current = null;
+      }
+    };
+  }, [tourActive, paused, pathname, router, routeOrder, user]);
+
+  const handleResume = useCallback(() => {
+    setPaused(false);
+    localStorage.removeItem(TOUR_PAUSED_KEY);
+    // Force the driver-loop effect to re-run by toggling tourActive
+    // off and back on — the effect's deps don't include `paused`'s
+    // false value transition reliably enough across React 19.
+    setTourActive(false);
+    setTimeout(() => setTourActive(true), 100);
+  }, []);
+
+  const handleEnd = useCallback(() => {
+    localStorage.removeItem(TOUR_KEY);
+    localStorage.removeItem(TOUR_PAUSED_KEY);
+    if (user?.email) {
+      localStorage.setItem(`${TOUR_SEEN_PREFIX}${user.email}`, "true");
+    }
+    api.markTourSeen().catch(() => {});
+    setTourActive(false);
+    setPaused(false);
+  }, [user]);
+
+  if (tourActive && paused) {
+    return <ResumeBanner onResume={handleResume} onEnd={handleEnd} />;
+  }
+  return null;
+}

--- a/frontend/src/components/tour/GuidedTour.tsx
+++ b/frontend/src/components/tour/GuidedTour.tsx
@@ -42,10 +42,10 @@ function ResumeBanner({ onResume, onEnd }: { onResume: () => void; onEnd: () => 
   return (
     <div className="tour-resume-banner" role="status" aria-live="polite">
       <span>Tour paused — explore freely</span>
-      <button className="tour-resume-btn" onClick={onResume}>
+      <button type="button" className="tour-resume-btn" onClick={onResume}>
         Resume Tour
       </button>
-      <button className="tour-end-btn" onClick={onEnd}>
+      <button type="button" className="tour-end-btn" onClick={onEnd}>
         End Tour
       </button>
     </div>
@@ -170,12 +170,30 @@ export default function GuidedTour() {
         prevBtnText: "Back",
         doneBtnText: isLastRoute ? "Finish Tour" : `Continue to ${nextLabel}`,
         onCloseClick: () => {
+          // X button / overlay click. Pause the tour but don't mark
+          // complete — user can resume from the banner.
           d.destroy();
           driverRef.current = null;
           setPaused(true);
           localStorage.setItem(TOUR_PAUSED_KEY, "true");
         },
         onDestroyStarted: () => {
+          // driver.js fires onDestroyStarted on EVERY destroy: explicit
+          // close, finish-button click, programmatic d.destroy() during
+          // cleanup. Cubic P1 on PR #63 caught the original handler
+          // unconditionally advancing routes / marking complete, so a
+          // close mid-route would incorrectly skip ahead.
+          //
+          // Only treat the destroy as "finish this route" when the user
+          // actually clicked the done button on the last step. Anything
+          // else (mid-step close, programmatic teardown from the
+          // useEffect cleanup) falls through to a pause.
+          const finishedRoute = d.isLastStep();
+          if (!finishedRoute) {
+            d.destroy();
+            driverRef.current = null;
+            return;
+          }
           if (isLastRoute) {
             // Tour fully completed — clear state + persist server-side.
             localStorage.removeItem(TOUR_KEY);

--- a/frontend/src/components/tour/StartTourButton.tsx
+++ b/frontend/src/components/tour/StartTourButton.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+/**
+ * Header button to (re-)start the guided tour from the current page.
+ *
+ * Disabled when the current pathname has no tour steps registered —
+ * this stays accurate as `tourSteps.ts` grows in Phase 2/3, no manual
+ * gating needed here.
+ */
+import { useCallback, useMemo } from "react";
+import { usePathname } from "next/navigation";
+import { PlayCircle } from "lucide-react";
+import { getUser } from "@/lib/auth";
+import {
+  getTourRouteOrder,
+  hasStepsForRoute,
+  normalizeTourPath,
+  TOUR_KEY,
+  TOUR_PAUSED_KEY,
+  TOUR_START_EVENT,
+} from "@/lib/tour/tourSteps";
+
+export default function StartTourButton({ className = "" }: { className?: string }) {
+  const pathname = usePathname();
+  const user = getUser();
+  const isAdmin = user?.role === "admin" || user?.role === "owner";
+  const routeOrder = useMemo(() => getTourRouteOrder(isAdmin), [isAdmin]);
+  const currentIndex = routeOrder.indexOf(normalizeTourPath(pathname));
+  const enabled = hasStepsForRoute(pathname) && currentIndex !== -1;
+
+  const startTour = useCallback(() => {
+    if (!enabled) return;
+    localStorage.setItem(TOUR_KEY, "true");
+    localStorage.removeItem(TOUR_PAUSED_KEY);
+    window.dispatchEvent(new Event(TOUR_START_EVENT));
+  }, [enabled]);
+
+  return (
+    <button
+      data-tour="header-tour-button"
+      onClick={startTour}
+      disabled={!enabled}
+      title={enabled ? "Start tour from this page" : "No tour for this page yet"}
+      aria-label={enabled ? "Start tour from this page" : "No tour for this page yet"}
+      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium text-ink-secondary hover:bg-surface-hover hover:text-ink transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-ink-secondary ${className}`}
+    >
+      <PlayCircle className="w-4 h-4" />
+      <span className="hidden md:inline text-xs">Tour</span>
+    </button>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -185,7 +185,19 @@ class ApiClient {
       organizationName: string;
       tenantId: string;
       integrations: Record<string, unknown>;
+      hasSeenTour?: boolean;
     }>("/api/auth/me");
+  }
+
+  /**
+   * Mark the guided tour as completed for the current user. Idempotent.
+   * Called by `GuidedTour.tsx` on auto-start (so re-login doesn't
+   * re-trigger) and again on Finish/End (so the localStorage flag
+   * matches the server). Best-effort — failures here just mean the
+   * tour might re-show on the next fresh login, not a hard error.
+   */
+  async markTourSeen() {
+    return this.post<Record<string, never>>("/api/auth/me/tour-seen");
   }
 
   // Dashboard

--- a/frontend/src/lib/tour/driver.css
+++ b/frontend/src/lib/tour/driver.css
@@ -1,0 +1,175 @@
+/* Guided Tour (driver.js) — themed for Workforce0.
+ * Picks up `--color-accent` from globals.css (indigo-600 by default).
+ * Originally ported from aether2.0's `lib/tour/driver.css`. */
+
+/* Force hover-only controls visible when their row is the tour's active element */
+.driver-active-element [data-context-menu],
+tr.driver-active-element [data-context-menu] {
+  opacity: 1 !important;
+}
+
+.driver-popover {
+  background: #1e293b !important;
+  color: #f1f5f9 !important;
+  border-radius: 12px !important;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5) !important;
+  max-width: 400px !important;
+  padding: 20px !important;
+  overflow: visible !important;
+}
+.driver-popover * {
+  overflow-wrap: break-word !important;
+  word-break: break-word !important;
+}
+.driver-popover-title {
+  color: #ffffff !important;
+  font-size: 17px !important;
+  font-weight: 700 !important;
+  margin-bottom: 8px !important;
+}
+.driver-popover-description {
+  color: #e2e8f0 !important;
+  font-size: 14px !important;
+  line-height: 1.65 !important;
+  max-height: 240px !important;
+  overflow-y: auto !important;
+}
+.driver-popover-footer {
+  margin-top: 16px !important;
+}
+.driver-popover-navigation-btns {
+  gap: 8px !important;
+}
+.driver-popover-navigation-btns button {
+  border-radius: 8px !important;
+  padding: 8px 16px !important;
+  font-size: 13px !important;
+  font-weight: 600 !important;
+  min-height: 36px !important;
+  white-space: nowrap !important;
+}
+.driver-popover-next-btn {
+  background: var(--color-accent, #4f46e5) !important;
+  color: #fff !important;
+  border: none !important;
+  text-shadow: none !important;
+}
+.driver-popover-next-btn:hover {
+  background: #2549d8 !important;
+}
+.driver-popover-prev-btn {
+  background: transparent !important;
+  color: #cbd5e1 !important;
+  border: 1px solid #475569 !important;
+  text-shadow: none !important;
+}
+.driver-popover-prev-btn:hover:not(:disabled) {
+  background: #334155 !important;
+  color: #f1f5f9 !important;
+}
+.driver-popover-prev-btn:disabled,
+.driver-popover-prev-btn[disabled] {
+  opacity: 1 !important;
+  color: #64748b !important;
+  border-color: #334155 !important;
+  background: transparent !important;
+  cursor: not-allowed !important;
+}
+.driver-popover-close-btn {
+  color: #94a3b8 !important;
+  font-size: 18px !important;
+  width: 28px !important;
+  height: 28px !important;
+}
+.driver-popover-close-btn:hover {
+  color: #f1f5f9 !important;
+}
+.driver-popover-arrow-side-left .driver-popover-arrow,
+.driver-popover-arrow-side-right .driver-popover-arrow,
+.driver-popover-arrow-side-top .driver-popover-arrow,
+.driver-popover-arrow-side-bottom .driver-popover-arrow {
+  border-color: #1e293b !important;
+}
+.driver-popover-progress-text {
+  color: #94a3b8 !important;
+  font-size: 12px !important;
+  font-weight: 500 !important;
+}
+
+.tour-explore-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 12px;
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #93c5fd;
+  border: 1px solid #2549d8;
+  background: transparent;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.tour-explore-btn:hover {
+  background: #2549d8;
+  color: #fff;
+}
+
+.tour-resume-banner {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 99999;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 20px;
+  background: #1e293b;
+  border: 1px solid var(--color-accent, #4f46e5);
+  border-radius: 12px;
+  box-shadow: 0 20px 40px -8px rgba(0, 0, 0, 0.4);
+  animation: tour-slide-up 0.3s ease-out;
+}
+.tour-resume-banner span {
+  color: #e2e8f0;
+  font-size: 14px;
+  font-weight: 500;
+}
+.tour-resume-banner button {
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  min-height: 36px;
+  cursor: pointer;
+  transition: all 0.15s;
+  border: none;
+}
+.tour-resume-btn {
+  background: var(--color-accent, #4f46e5);
+  color: #fff;
+}
+.tour-resume-btn:hover {
+  background: #2549d8;
+}
+.tour-end-btn {
+  background: transparent;
+  color: #94a3b8;
+  border: 1px solid #475569 !important;
+}
+.tour-end-btn:hover {
+  background: #334155;
+  color: #f1f5f9;
+}
+@keyframes tour-slide-up {
+  from {
+    transform: translateX(-50%) translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(-50%) translateY(0);
+    opacity: 1;
+  }
+}

--- a/frontend/src/lib/tour/tourSteps.ts
+++ b/frontend/src/lib/tour/tourSteps.ts
@@ -1,0 +1,293 @@
+/**
+ * Workforce0 guided tour step definitions.
+ *
+ * Architecture
+ * ────────────
+ * Every page that participates in the tour gets:
+ *   1. A list of `DriveStep`s built here (route → step list)
+ *   2. `data-tour="..."` anchors on the elements those steps highlight
+ *
+ * `GuidedTour.tsx` reads the current pathname, fetches the matching step
+ * list, drives it, then advances to the next route in `TOUR_ROUTE_ORDER`.
+ *
+ * This is Phase 1 — five pages curated for first-time setup of the four
+ * capabilities a Workforce0 install enables: voice intake, meeting note-
+ * taker, WhatsApp, dev+PR. The remaining dashboard pages get tour
+ * coverage in follow-up PRs (issue #44 follow-up + sister tickets).
+ *
+ * Originally adapted from aether2.0's `lib/tour/tourSteps.ts`.
+ */
+import { DriveStep } from "driver.js";
+
+const EXPLORE_BTN =
+  '<br/><button class="tour-explore-btn" onclick="window.dispatchEvent(new Event(\'wf0-tour-pause\'))">Explore on your own</button>';
+
+function buildDashboardSteps(): DriveStep[] {
+  return [
+    {
+      popover: {
+        title: "Welcome to Workforce0",
+        description:
+          "We'll walk you through the four things a fresh install gives " +
+          "your team: take voice calls, record meetings, send WhatsApp " +
+          "approvals, and ship code — all powered by AI agents." +
+          EXPLORE_BTN,
+        side: "bottom",
+        align: "center",
+      },
+    },
+    {
+      element: '[data-tour="sidebar-nav"]',
+      popover: {
+        title: "Your control room",
+        description:
+          "Everything lives here. Engagements is the chief-of-staff " +
+          "agent's task list, Meetings is your call history, and " +
+          "Settings → Integrations is where this whole tour ends.",
+        side: "right",
+        align: "start",
+      },
+    },
+    {
+      element: '[data-tour="header-tour-button"]',
+      popover: {
+        title: "Restart this tour anytime",
+        description:
+          "If you want a refresher later, click the Tour button in the " +
+          "top bar. The tour resumes from whichever page you're on.",
+        side: "bottom",
+        align: "end",
+      },
+    },
+  ];
+}
+
+function buildIntegrationsSteps(): DriveStep[] {
+  return [
+    {
+      element: '[data-tour="integrations-header"]',
+      popover: {
+        title: "Connect once, use everywhere",
+        description:
+          "All AI keys, Twilio creds, and SaaS tokens live here. Stored " +
+          "encrypted per tenant; never logged. Hot-reloads — no backend " +
+          "restart needed when you save.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+    {
+      element: '[data-tour="integration-card-twilio"]',
+      popover: {
+        title: "Twilio: voice + WhatsApp",
+        description:
+          "One Twilio account drives both inbound voice calls and " +
+          "WhatsApp approvals. Click Connect, paste Account SID + Auth " +
+          "Token + your number, and the wizard tests it against the " +
+          "Twilio API live.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+    {
+      element: '[data-tour="integration-card-github"]',
+      popover: {
+        title: "GitHub: ship code",
+        description:
+          "Connect a fine-grained GitHub PAT scoped to the repos you " +
+          "want the AI to push branches and open PRs against. The dev " +
+          "agent uses this for end-to-end ticket → PR work.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+    {
+      element: '[data-tour="integration-card-slack"]',
+      popover: {
+        title: "Slack (or Google Chat) for daily comms",
+        description:
+          "The chief-of-staff agent posts briefs and approval requests " +
+          "here. Replies feed back into the workflow — so your team " +
+          "approves work without ever opening this dashboard.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+  ];
+}
+
+function buildMeetingsSteps(): DriveStep[] {
+  return [
+    {
+      element: '[data-tour="meetings-header"]',
+      popover: {
+        title: "Meetings — calls + recordings in one place",
+        description:
+          "Every inbound voice call and uploaded recording lands here. " +
+          "Auto-transcribed locally (whisper), summarised by your AI " +
+          "council, action items extracted into tickets.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+    {
+      element: '[data-tour="meetings-upload"]',
+      popover: {
+        title: "Drop a recording",
+        description:
+          "Upload a Zoom/Meet/Teams recording (mp3, mp4, m4a) and " +
+          "Workforce0 transcribes + summarises it. No bot has to join " +
+          "the call.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+    {
+      element: '[data-tour="meetings-voice-dialin"]',
+      popover: {
+        title: "Have the AI join a live call",
+        description:
+          "Click here to dial the AI into an active Meet/Zoom " +
+          "conference as a participant. Pick Silent Observer (just " +
+          "transcribes) or Active Participant (answers questions when " +
+          "addressed by name).",
+        side: "bottom",
+        align: "end",
+      },
+    },
+  ];
+}
+
+function buildEngagementsSteps(): DriveStep[] {
+  return [
+    {
+      element: '[data-tour="engagements-header"]',
+      popover: {
+        title: "Engagements — the agent's work tracker",
+        description:
+          "Every brief goes through phases: drafted → reviewed → " +
+          "approved → in-progress → done. The chief-of-staff agent " +
+          "manages this for you — you only step in to approve or " +
+          "redirect.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+    {
+      element: '[data-tour="engagements-list"]',
+      popover: {
+        title: "All your active engagements",
+        description:
+          "Anything the AI is working on — a meeting brief, a feature " +
+          "spec, a customer follow-up. Click one to see the agent's " +
+          "reasoning trace and intermediate outputs.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+  ];
+}
+
+function buildPrdsSteps(): DriveStep[] {
+  return [
+    {
+      element: '[data-tour="prds-header"]',
+      popover: {
+        title: "Briefs — auto-generated from meetings",
+        description:
+          "After every meeting (call, recording, dial-in), the BA " +
+          "agent drafts a structured brief: problem, scope, success " +
+          "criteria, acceptance tests. You approve it (or edit), and " +
+          "the dev agent picks it up to write code + open a PR.",
+        side: "bottom",
+        align: "start",
+      },
+    },
+    {
+      element: '[data-tour="prds-create"]',
+      popover: {
+        title: "Approve once, ship many",
+        description:
+          "Briefs that need your attention surface here. One click to " +
+          "approve, the dev agent creates Jira tickets and (if GitHub " +
+          "is connected) raises the PR. You only step in when the AI " +
+          "council can't agree.",
+        side: "bottom",
+        align: "end",
+      },
+    },
+    {
+      popover: {
+        title: "You're set up",
+        description:
+          "Voice in, meetings transcribed, briefs auto-generated, " +
+          "code shipped via PR, approvals over Slack/WhatsApp. Day-to-" +
+          "day the exec lives in their phone — you live wherever you " +
+          "want. Hit the Tour button anytime for a refresher.",
+        side: "bottom",
+        align: "center",
+      },
+    },
+  ];
+}
+
+const STATIC_TOUR_STEPS: Record<string, DriveStep[]> = {
+  "/dashboard": buildDashboardSteps(),
+  "/settings/integrations": buildIntegrationsSteps(),
+  "/meetings": buildMeetingsSteps(),
+  "/engagements": buildEngagementsSteps(),
+  "/prds": buildPrdsSteps(),
+};
+
+const BASE_TOUR_ROUTE_ORDER = [
+  "/dashboard",
+  "/settings/integrations",
+  "/meetings",
+  "/engagements",
+  "/prds",
+];
+
+export function getTourRouteOrder(_isAdmin: boolean): string[] {
+  // No admin-only tour pages in Phase 1. Argument kept so the call site
+  // stays stable when admin-only steps land in Phase 2.
+  return BASE_TOUR_ROUTE_ORDER;
+}
+
+export const TOUR_ROUTE_ORDER = BASE_TOUR_ROUTE_ORDER;
+
+export const ROUTE_LABELS: Record<string, string> = {
+  "/dashboard": "Dashboard",
+  "/settings/integrations": "Integrations",
+  "/meetings": "Meetings",
+  "/engagements": "Engagements",
+  "/prds": "PRDs",
+};
+
+export function normalizeTourPath(pathname: string): string {
+  // Match nested routes like `/settings/integrations/...` against the
+  // exact `/settings/integrations` step list. Order matters — longer
+  // prefixes win.
+  const knownPrefixes = ["/settings/integrations"];
+  for (const prefix of knownPrefixes) {
+    if (pathname === prefix || pathname.startsWith(prefix + "/")) return prefix;
+  }
+  const parts = pathname.split("/").filter(Boolean);
+  return "/" + (parts[0] || "");
+}
+
+export function getStepsForRoute(pathname: string): DriveStep[] | undefined {
+  return STATIC_TOUR_STEPS[normalizeTourPath(pathname)];
+}
+
+export function hasStepsForRoute(pathname: string): boolean {
+  const normalized = normalizeTourPath(pathname);
+  return Array.isArray(STATIC_TOUR_STEPS[normalized]) &&
+    STATIC_TOUR_STEPS[normalized].length > 0;
+}
+
+export const TOUR_KEY = "wf0_tour_active";
+export const TOUR_PAUSED_KEY = "wf0_tour_paused";
+export const TOUR_SEEN_PREFIX = "wf0_tour_seen_";
+
+export const TOUR_START_EVENT = "wf0-tour-start";
+export const TOUR_PAUSE_EVENT = "wf0-tour-pause";

--- a/frontend/src/lib/tour/tourSteps.ts
+++ b/frontend/src/lib/tour/tourSteps.ts
@@ -19,8 +19,17 @@
  */
 import { DriveStep } from "driver.js";
 
+// Names hoisted so the EXPLORE_BTN HTML below can reference the
+// pause-event constant without duplicating the string literal.
+export const TOUR_KEY = "wf0_tour_active";
+export const TOUR_PAUSED_KEY = "wf0_tour_paused";
+export const TOUR_SEEN_PREFIX = "wf0_tour_seen_";
+
+export const TOUR_START_EVENT = "wf0-tour-start";
+export const TOUR_PAUSE_EVENT = "wf0-tour-pause";
+
 const EXPLORE_BTN =
-  '<br/><button class="tour-explore-btn" onclick="window.dispatchEvent(new Event(\'wf0-tour-pause\'))">Explore on your own</button>';
+  `<br/><button class="tour-explore-btn" onclick="window.dispatchEvent(new Event('${TOUR_PAUSE_EVENT}'))">Explore on your own</button>`;
 
 function buildDashboardSteps(): DriveStep[] {
   return [
@@ -284,10 +293,3 @@ export function hasStepsForRoute(pathname: string): boolean {
   return Array.isArray(STATIC_TOUR_STEPS[normalized]) &&
     STATIC_TOUR_STEPS[normalized].length > 0;
 }
-
-export const TOUR_KEY = "wf0_tour_active";
-export const TOUR_PAUSED_KEY = "wf0_tour_paused";
-export const TOUR_SEEN_PREFIX = "wf0_tour_seen_";
-
-export const TOUR_START_EVENT = "wf0-tour-start";
-export const TOUR_PAUSE_EVENT = "wf0-tour-pause";


### PR DESCRIPTION
## Summary

In-app guided tour modeled on aether2.0's pattern. First-login
auto-walks new users through the four capabilities a fresh Workforce0
install gives them: voice intake, meeting note-taker, WhatsApp
approvals, dev+PR.

**Phase 1 of 3.** Phase 2 = anchors on remaining 12 pages. Phase 3 =
end-to-end "configure the bare minimum" guided onboarding (separate
spec — design questions about voice path, note-taker source, WhatsApp
provider, dev+PR template).

## What changed

**Backend**
- `User.hasSeenTour` boolean (Prisma migration `20260427000000_add_user_has_seen_tour`)
- `GET /auth/me` returns `hasSeenTour`
- `POST /auth/me/tour-seen` — idempotent mark-as-complete

**Frontend**
- `driver.js@^1.4.0` installed
- `lib/tour/driver.css` — themed for Workforce0's `--color-accent` (indigo-600)
- `lib/tour/tourSteps.ts` — per-route step builders + route order
- `components/tour/GuidedTour.tsx` — orchestrator (auto-start, pause/resume, route advance)
- `components/tour/StartTourButton.tsx` — header restart button, disabled when current page has no steps
- `data-tour` anchors on **5 pages**: dashboard, settings/integrations, meetings, engagements, prds

**Tour route order:**
\`/dashboard\` → \`/settings/integrations\` → \`/meetings\` → \`/engagements\` → \`/prds\`

## What's not in this PR

- **Anchors on remaining 12 dashboard pages** (agent-jobs, analytics, approvals, goals, graph, library, projects, schedules, skills, tasks, team, settings root). Phase 2 — small per-page batches.
- **Phase 3: configure-bare-minimum onboarding tour.** Different concept — the tour writes config along the way. Needs a spec because each capability has 2-3 valid paths (inbound vs outbound voice, Vexa vs Meet upload, Twilio WhatsApp vs other, GitHub vs Linear).

## Verification

- Backend: 1906/1906 tests pass
- Frontend: 97/97 actual tests pass (2 pre-existing test files fail on main same way — `lucide-react` mock issue, unrelated)
- `tsc --noEmit`: clean both ends

## Test plan

- [ ] Run migration: \`npx prisma migrate deploy\` in backend
- [ ] Sign up as a new user — tour auto-starts on \`/dashboard\`
- [ ] Click "Continue to Integrations" — tour advances + lands on the right page with anchors highlighted
- [ ] Walk through to \`/prds\` — final step shows "Finish Tour" button
- [ ] Click Finish — \`hasSeenTour\` set true on user row, no auto-restart on next login
- [ ] Refresh browser mid-tour — tour resumes from current step
- [ ] Click "Explore on your own" inside any step — paused banner appears + tour stops
- [ ] Click Resume from the banner — tour resumes
- [ ] Click "End Tour" from the banner — \`hasSeenTour\` set true, tour clears
- [ ] On any tour-eligible page, click the Tour button in header — tour restarts from that page
- [ ] On a non-tour page (e.g. /skills), the Tour button shows disabled with hover hint

## Bot review expectations

- CodeRabbit / Cubic: anchor placement, accessibility (sr-only span hack on Header — open to better suggestion), driver.js animation perf
- CodeQL: no new alerts expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive guided tour across dashboard sections (engagements, meetings, PRDs, integrations, settings) with play button and resume banner
  * Auto-start for first-time users, manual start available, and pause/resume mid-tour
  * Tour progress persists locally and is now saved server-side so completion is remembered across devices

* **Bug Fixes**
  * Improved reliability when navigating routes during an active tour
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guided onboarding tour (Phase 1) on five pages with auto-start, pause/resume, cross-page advance, and completion tracking using `driver.js`. Also tightens close behavior, backend guards, and rate limiting to make the tour reliable.

- **Bug Fixes**
  - Closing mid-tour now pauses without advancing; only the final step advances or marks complete.
  - `GET /auth/me` returns 401 when the user row is missing (deleted account) and still includes `hasSeenTour`; test added.
  - `POST /auth/me/tour-seen` is rate-limited (10/min) and returns 404 if the user was deleted; still idempotent.
  - Moved `data-tour` anchors to visible elements on Meetings and PRDs to fix highlight targeting.

- **Migration**
  - Run: `npx prisma migrate deploy` in `backend`.

<sup>Written for commit a05b6d2005257ac8817c51cd5ff0592e4b65e423. Summary will update on new commits. <a href="https://cubic.dev/pr/workforce0/workforce0/pull/63?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

