### PR TITLE
fix(frontend): pass BACKEND_URL build arg to next.config rewrites

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,6 +18,15 @@ RUN npm ci
 # Copy source code and config
 COPY . .
 
+# next.config.ts evaluates `process.env.BACKEND_URL` at build time to bake
+# the /api/* and /webhooks/* rewrite destinations into the standalone
+# output. Without ARG + ENV plumbing here the compose `args.BACKEND_URL`
+# is invisible to `npm run build` and rewrites fall back to
+# http://127.0.0.1:3000 — which inside the frontend container points at
+# nothing, so every /api/* call ECONNREFUSEDs.
+ARG BACKEND_URL=http://backend:3000
+ENV BACKEND_URL=$BACKEND_URL
+
 # Build Next.js (standalone output)
 RUN npm run build
 


### PR DESCRIPTION
## Problem

Every \`/api/*\` request from the browser through the frontend container
returns HTTP 500. Frontend logs show:

\`\`\`
Failed to proxy http://127.0.0.1:3000/api/auth/login
Error: connect ECONNREFUSED 127.0.0.1:3000
\`\`\`

## Root cause

\`next.config.ts\`:
\`\`\`ts
const backendUrl = process.env.BACKEND_URL || "http://127.0.0.1:3000";
async rewrites() {
  return [
    { source: "/api/:path*", destination: \`\${backendUrl}/api/:path*\` },
    ...
  ];
}
\`\`\`

\`process.env.BACKEND_URL\` is read at **build time** (Next bakes the
rewrite destinations into the standalone output). The compose-level
\`args.BACKEND_URL\` is passed to \`docker build\`, but the Dockerfile
never declares \`ARG BACKEND_URL\` or exports it via \`ENV\` before
\`RUN npm run build\`, so the build runs without it. The fallback
\`http://127.0.0.1:3000\` gets baked in — which inside the frontend
container points at nothing.

## Fix

Three lines in \`frontend/Dockerfile\`:

\`\`\`dockerfile
ARG BACKEND_URL=http://backend:3000
ENV BACKEND_URL=$BACKEND_URL
\`\`\`

Inserted before \`RUN npm run build\`. Default (\`http://backend:3000\`)
matches the docker-compose service-name DNS that ships with the prod
stack, so existing self-hosters get the right behavior with no
\`.env\` change. Anyone with a non-default topology can still override
via compose's \`args.BACKEND_URL\`.

## Verification

Local rebuild + recreate of \`wf0-voice-frontend\`. Pre-fix:
\`POST http://localhost:23001/api/auth/login\` → 500 (ECONNREFUSED).
Post-fix: \`POST .../api/auth/login\` → \`HTTP 400 VALIDATION_ERROR\`
(backend reached, body validated, expected response for empty creds).

## History note

Same fix was applied on a discarded branch during the PR #47 cycle but
never made it to main — the rebase that landed the wizard kept only
the wizard changes. Surfacing standalone here so the fix sticks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker configuration to ensure proper backend service connectivity during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix frontend API proxying by passing `BACKEND_URL` into the build so `next.config.ts` bakes the correct backend URL into rewrites. Adds `ARG BACKEND_URL=http://backend:3000` and `ENV BACKEND_URL=$BACKEND_URL` before the build to prevent ECONNREFUSED 500s and route `/api/*` to the backend by default (override via compose `args.BACKEND_URL`).

<sup>Written for commit ec2aaa865a6c517fbe3f986fb1fb26da550f7ef7. Summary will update on new commits. <a href="https://cubic.dev/pr/workforce0/workforce0/pull/66?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

