### PR TITLE
feat(tour): light-card redesign — branded step badge, soft halo, animated

### DIFF
--- a/frontend/src/components/tour/GuidedTour.tsx
+++ b/frontend/src/components/tour/GuidedTour.tsx
@@ -159,6 +159,19 @@ export default function GuidedTour() {
 
       const steps: DriveStep[] = baseSteps;
 
+      // Total = sum of every route's step count, so the badge reads
+      // "STEP 4 OF 13" across the whole tour rather than per-page.
+      // Re-imported here (vs hoisted) so the lookup re-runs cheaply on
+      // every route change without leaking a stale closure.
+      const totalSteps = routeOrder.reduce((sum, r) => {
+        const s = getStepsForRoute(r) ?? [];
+        return sum + s.length;
+      }, 0);
+      const stepsBefore = routeOrder.slice(0, currentRouteIndex).reduce((sum, r) => {
+        const s = getStepsForRoute(r) ?? [];
+        return sum + s.length;
+      }, 0);
+
       const d = driver({
         showProgress: true,
         animate: true,
@@ -169,6 +182,19 @@ export default function GuidedTour() {
         nextBtnText: "Next",
         prevBtnText: "Back",
         doneBtnText: isLastRoute ? "Finish Tour" : `Continue to ${nextLabel}`,
+        // Stamp a global step counter onto the popover for our CSS
+        // ::before badge to render. driver.js's own progress text is
+        // hidden via `display:none` in driver.css.
+        onPopoverRender: (popover) => {
+          const idx = d.getActiveIndex();
+          if (typeof idx === "number") {
+            const globalStep = stepsBefore + idx + 1;
+            popover.wrapper.setAttribute(
+              "data-step-progress",
+              `STEP ${globalStep} OF ${totalSteps}`,
+            );
+          }
+        },
         onCloseClick: () => {
           // X button / overlay click. Pause the tour but don't mark
           // complete — user can resume from the banner.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -195,9 +195,14 @@ class ApiClient {
    * re-trigger) and again on Finish/End (so the localStorage flag
    * matches the server). Best-effort — failures here just mean the
    * tour might re-show on the next fresh login, not a hard error.
+   *
+   * The empty-object body is deliberate: `request()` always sets
+   * `Content-Type: application/json` and Fastify rejects empty bodies
+   * on a JSON content-type with HTTP 400. Sending `{}` makes the body
+   * a valid empty JSON document.
    */
   async markTourSeen() {
-    return this.post<Record<string, never>>("/api/auth/me/tour-seen");
+    return this.post<Record<string, never>>("/api/auth/me/tour-seen", {});
   }
 
   // Dashboard

--- a/frontend/src/lib/tour/driver.css
+++ b/frontend/src/lib/tour/driver.css
@@ -1,121 +1,215 @@
-/* Guided Tour (driver.js) — themed for Workforce0.
- * Picks up `--color-accent` from globals.css (indigo-600 by default).
- * Originally ported from aether2.0's `lib/tour/driver.css`. */
+/* Guided Tour — Workforce0 (light theme).
+ *
+ * Replaces the dark-navy default driver.js popover with a light, branded
+ * card style:
+ *   - White surface, soft branded shadow
+ *   - 16px radius, subtle accent ring
+ *   - Animated entrance (slide + fade)
+ *   - Numbered step badge in the corner
+ *   - Branded primary button, ghost secondary, large hit targets
+ *   - Spotlight overlay with rounded clip
+ *
+ * Picks up `--color-accent` from globals.css (indigo-600) for brand match.
+ */
 
-/* Force hover-only controls visible when their row is the tour's active element */
+/* Reveal hover-only context controls when a row is the tour target. */
 .driver-active-element [data-context-menu],
 tr.driver-active-element [data-context-menu] {
   opacity: 1 !important;
 }
 
+/* ───────────────────────── Popover shell ─────────────────────────── */
 .driver-popover {
-  background: #1e293b !important;
-  color: #f1f5f9 !important;
-  border-radius: 12px !important;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5) !important;
-  max-width: 400px !important;
-  padding: 20px !important;
+  background: #ffffff !important;
+  color: #0f172a !important;
+  border-radius: 16px !important;
+  box-shadow:
+    0 1px 0 rgba(15, 23, 42, 0.04),
+    0 18px 40px -8px rgba(15, 23, 42, 0.18),
+    0 4px 14px -2px rgba(79, 70, 229, 0.10) !important;
+  max-width: 380px !important;
+  padding: 22px 22px 18px 22px !important;
+  border: 1px solid rgba(79, 70, 229, 0.10) !important;
+  font-family: inherit !important;
+  position: relative !important;
   overflow: visible !important;
+  animation: wf0-tour-pop 220ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
+
+@keyframes wf0-tour-pop {
+  0%   { opacity: 0; transform: translateY(8px) scale(0.98); }
+  100% { opacity: 1; transform: translateY(0)   scale(1); }
+}
+
 .driver-popover * {
   overflow-wrap: break-word !important;
   word-break: break-word !important;
 }
-.driver-popover-title {
-  color: #ffffff !important;
-  font-size: 17px !important;
-  font-weight: 700 !important;
-  margin-bottom: 8px !important;
+
+/* Step counter badge (we hide driver.js's default progress text and
+ * synthesize our own from the data-driver-popover-progress attr that the
+ * library writes). */
+.driver-popover-progress-text {
+  display: none !important;
 }
+.driver-popover::before {
+  content: attr(data-step-progress);
+  position: absolute;
+  top: -14px;
+  left: 22px;
+  background: var(--color-accent, #4f46e5);
+  color: #ffffff;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  padding: 5px 10px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  box-shadow: 0 4px 10px -2px rgba(79, 70, 229, 0.40);
+}
+/* If JS hasn't written data-step-progress, fall back to a generic dot. */
+.driver-popover:not([data-step-progress])::before {
+  content: "TIP";
+}
+
+/* ───────────────────────── Title + body ──────────────────────────── */
+.driver-popover-title {
+  color: #0f172a !important;
+  font-size: 17px !important;
+  font-weight: 600 !important;
+  letter-spacing: -0.01em !important;
+  line-height: 1.35 !important;
+  margin: 4px 0 8px 0 !important;
+  padding-right: 28px !important; /* leave room for close X */
+}
+
 .driver-popover-description {
-  color: #e2e8f0 !important;
-  font-size: 14px !important;
+  color: #475569 !important;
+  font-size: 13.5px !important;
   line-height: 1.65 !important;
-  max-height: 240px !important;
+  max-height: 260px !important;
   overflow-y: auto !important;
 }
-.driver-popover-footer {
-  margin-top: 16px !important;
+
+/* Inline "Explore on your own" pause button. */
+.tour-explore-btn {
+  display: inline-block;
+  margin-top: 10px;
+  padding: 6px 12px;
+  background: transparent;
+  color: var(--color-accent, #4f46e5);
+  border: 1px solid rgba(79, 70, 229, 0.25);
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 120ms, border-color 120ms;
 }
+.tour-explore-btn:hover {
+  background: rgba(79, 70, 229, 0.06);
+  border-color: rgba(79, 70, 229, 0.45);
+}
+
+/* ───────────────────────── Footer / buttons ──────────────────────── */
+.driver-popover-footer {
+  margin-top: 18px !important;
+  padding-top: 14px !important;
+  border-top: 1px solid rgba(15, 23, 42, 0.06) !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: flex-end !important;
+  gap: 8px !important;
+}
+
 .driver-popover-navigation-btns {
   gap: 8px !important;
 }
+
 .driver-popover-navigation-btns button {
-  border-radius: 8px !important;
-  padding: 8px 16px !important;
+  border-radius: 10px !important;
+  padding: 9px 16px !important;
   font-size: 13px !important;
   font-weight: 600 !important;
-  min-height: 36px !important;
+  min-height: 38px !important;
   white-space: nowrap !important;
+  font-family: inherit !important;
+  letter-spacing: -0.005em !important;
+  transition: transform 120ms, box-shadow 120ms, background 120ms !important;
 }
-.driver-popover-next-btn {
-  background: var(--color-accent, #4f46e5) !important;
-  color: #fff !important;
-  border: none !important;
-  text-shadow: none !important;
-}
-.driver-popover-next-btn:hover {
-  background: #2549d8 !important;
-}
+
 .driver-popover-prev-btn {
   background: transparent !important;
-  color: #cbd5e1 !important;
-  border: 1px solid #475569 !important;
-  text-shadow: none !important;
-}
-.driver-popover-prev-btn:hover:not(:disabled) {
-  background: #334155 !important;
-  color: #f1f5f9 !important;
-}
-.driver-popover-prev-btn:disabled,
-.driver-popover-prev-btn[disabled] {
-  opacity: 1 !important;
   color: #64748b !important;
-  border-color: #334155 !important;
-  background: transparent !important;
-  cursor: not-allowed !important;
+  border: 1px solid #e2e8f0 !important;
 }
+.driver-popover-prev-btn:hover {
+  background: #f1f5f9 !important;
+  color: #0f172a !important;
+  border-color: #cbd5e1 !important;
+}
+
+.driver-popover-next-btn {
+  background: var(--color-accent, #4f46e5) !important;
+  color: #ffffff !important;
+  border: none !important;
+  box-shadow: 0 6px 16px -6px rgba(79, 70, 229, 0.50) !important;
+}
+.driver-popover-next-btn:hover {
+  background: var(--color-accent-hover, #4338ca) !important;
+  transform: translateY(-1px);
+  box-shadow: 0 10px 22px -6px rgba(79, 70, 229, 0.55) !important;
+}
+.driver-popover-next-btn:active {
+  transform: translateY(0);
+}
+
 .driver-popover-close-btn {
+  position: absolute !important;
+  top: 14px !important;
+  right: 14px !important;
+  width: 26px !important;
+  height: 26px !important;
+  border-radius: 8px !important;
   color: #94a3b8 !important;
+  background: transparent !important;
+  border: none !important;
   font-size: 18px !important;
-  width: 28px !important;
-  height: 28px !important;
+  line-height: 1 !important;
+  cursor: pointer !important;
+  transition: background-color 120ms, color 120ms !important;
 }
 .driver-popover-close-btn:hover {
-  color: #f1f5f9 !important;
-}
-.driver-popover-arrow-side-left .driver-popover-arrow,
-.driver-popover-arrow-side-right .driver-popover-arrow,
-.driver-popover-arrow-side-top .driver-popover-arrow,
-.driver-popover-arrow-side-bottom .driver-popover-arrow {
-  border-color: #1e293b !important;
-}
-.driver-popover-progress-text {
-  color: #94a3b8 !important;
-  font-size: 12px !important;
-  font-weight: 500 !important;
+  background: #f1f5f9 !important;
+  color: #0f172a !important;
 }
 
-.tour-explore-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 12px;
-  padding: 6px 14px;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 600;
-  color: #93c5fd;
-  border: 1px solid #2549d8;
-  background: transparent;
-  cursor: pointer;
-  transition: all 0.15s;
-}
-.tour-explore-btn:hover {
-  background: #2549d8;
-  color: #fff;
+/* Arrow tip — keep colored to match popover background. */
+.driver-popover-arrow-side-bottom.driver-popover-arrow,
+.driver-popover-arrow-side-top.driver-popover-arrow,
+.driver-popover-arrow-side-left.driver-popover-arrow,
+.driver-popover-arrow-side-right.driver-popover-arrow {
+  border-color: #ffffff !important;
 }
 
+/* ───────────────────── Spotlight + overlay ───────────────────────── */
+.driver-overlay {
+  /* Slightly less opaque + cooler tint than the default — feels less
+   * "modal", more "spotlight". */
+  fill: rgba(15, 23, 42, 0.45) !important;
+}
+
+.driver-active-element,
+[class*=driver-active-element] {
+  /* Soft branded ring around the highlighted element. */
+  box-shadow:
+    0 0 0 4px rgba(79, 70, 229, 0.18),
+    0 0 0 1px rgba(79, 70, 229, 0.55),
+    0 18px 40px -10px rgba(79, 70, 229, 0.20) !important;
+  border-radius: 10px !important;
+  transition: box-shadow 220ms ease-out !important;
+}
+
+/* ───────────────── Resume banner (paused state) ──────────────────── */
 .tour-resume-banner {
   position: fixed;
   bottom: 24px;
@@ -125,51 +219,82 @@ tr.driver-active-element [data-context-menu] {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 12px 20px;
-  background: #1e293b;
-  border: 1px solid var(--color-accent, #4f46e5);
-  border-radius: 12px;
-  box-shadow: 0 20px 40px -8px rgba(0, 0, 0, 0.4);
-  animation: tour-slide-up 0.3s ease-out;
-}
-.tour-resume-banner span {
-  color: #e2e8f0;
-  font-size: 14px;
+  background: #ffffff;
+  color: #0f172a;
+  padding: 12px 16px;
+  border-radius: 14px;
+  box-shadow:
+    0 1px 0 rgba(15, 23, 42, 0.04),
+    0 18px 40px -8px rgba(15, 23, 42, 0.20),
+    0 4px 14px -2px rgba(79, 70, 229, 0.12);
+  border: 1px solid rgba(79, 70, 229, 0.14);
+  font-size: 13.5px;
   font-weight: 500;
+  font-family: inherit;
+  animation: wf0-tour-pop 220ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
-.tour-resume-banner button {
-  padding: 8px 16px;
-  border-radius: 8px;
+
+.tour-resume-banner > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: #475569;
+}
+.tour-resume-banner > span::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--color-accent, #4f46e5);
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.18);
+  animation: wf0-tour-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes wf0-tour-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%      { opacity: 0.55; transform: scale(0.85); }
+}
+
+.tour-resume-btn,
+.tour-end-btn {
+  border: none;
+  border-radius: 10px;
+  padding: 7px 14px;
   font-size: 13px;
   font-weight: 600;
-  min-height: 36px;
   cursor: pointer;
-  transition: all 0.15s;
-  border: none;
+  font-family: inherit;
+  transition: background-color 120ms, color 120ms, transform 120ms;
 }
 .tour-resume-btn {
   background: var(--color-accent, #4f46e5);
-  color: #fff;
+  color: #ffffff;
+  box-shadow: 0 4px 12px -4px rgba(79, 70, 229, 0.40);
 }
 .tour-resume-btn:hover {
-  background: #2549d8;
+  background: var(--color-accent-hover, #4338ca);
+  transform: translateY(-1px);
 }
 .tour-end-btn {
   background: transparent;
-  color: #94a3b8;
-  border: 1px solid #475569 !important;
+  color: #64748b;
 }
 .tour-end-btn:hover {
-  background: #334155;
-  color: #f1f5f9;
+  background: #f1f5f9;
+  color: #0f172a;
 }
-@keyframes tour-slide-up {
-  from {
-    transform: translateX(-50%) translateY(20px);
-    opacity: 0;
+
+/* Match all overrides on small viewports. */
+@media (max-width: 480px) {
+  .driver-popover {
+    max-width: calc(100vw - 32px) !important;
+    padding: 18px 18px 14px !important;
   }
-  to {
-    transform: translateX(-50%) translateY(0);
-    opacity: 1;
+  .tour-resume-banner {
+    left: 16px;
+    right: 16px;
+    transform: none;
+    bottom: 16px;
+    flex-wrap: wrap;
   }
 }


### PR DESCRIPTION
Stacks on PR #63 (already merged). User feedback: dark-navy popover off-brand. Replaced with light, modern, branded card.

## What changed

**Visual**
- White surface, soft branded shadow, 16px radius, accent ring
- Numbered step badge upper-left (\`STEP 4 OF 13\`) — counts across the whole tour, not per-page
- Animated entrance (slide + fade, 220ms cubic-bezier)
- Branded indigo-600 primary button with hover lift + soft glow
- Ghost secondary button
- Soft branded halo around the spotlighted element (4px / 1px indigo)
- Lighter overlay (45%) — spotlight feel, not modal
- Pulsing dot in resume banner

**Implementation**
- \`driver.css\` fully rewritten with \`!important\` overrides + branded variables
- \`GuidedTour.tsx\` adds \`onPopoverRender\` hook that stamps \`data-step-progress\` onto the popover wrapper, picked up by CSS \`::before\` pseudo for the badge
- Default \`.driver-popover-progress-text\` hidden (replaced by the badge)
- Step counter math: sums step lists across every route in \`routeOrder\` so total stays accurate as Phase 2 lands more pages

**Responsive**
- Below 480px: popover full-width minus 32px gutters, banner spans bottom edge

No backend / API / migration changes.

Replaces closed #68.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Redesigned tour UI with light, branded theme and improved entrance animations
  * Implemented global step progress counter across all tour routes
  * Enhanced button styling and responsive design for all screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the tour popover to a light, branded card with a global step badge, soft halo, and smooth animation. Also fixed tour state persistence by sending an empty JSON body to the `markTourSeen` endpoint.

- **New Features**
  - Light card popover: white surface, 16px radius, subtle accent ring, and slide+fade animation.
  - Global step badge (“STEP n OF total”) replaces default progress text; counts across all routes.
  - Softer overlay and branded halo around the highlighted element; refreshed resume banner with pulsing dot.
  - Buttons: indigo primary with hover lift and ghost secondary.
  - Responsive: full-width popover on small screens.
  - Implementation: added `onPopoverRender` in `GuidedTour.tsx` to set `data-step-progress`; rewrote `driver.css` with targeted overrides.

- **Bug Fixes**
  - `markTourSeen()` now posts `{}` so Fastify accepts the JSON request, ensuring the tour “seen” flag persists and the tour doesn’t re-trigger.

<sup>Written for commit 72386dc1db90a695fcff60941b7a6f15ee467bcb. Summary will update on new commits. <a href="https://cubic.dev/pr/workforce0/workforce0/pull/69">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

